### PR TITLE
feature: add `WorkerConfig.app_config_path`

### DIFF
--- a/icij-worker/icij_worker/worker/config.py
+++ b/icij-worker/icij_worker/worker/config.py
@@ -13,6 +13,7 @@ from icij_worker.utils.registrable import RegistrableConfig
 class WorkerConfig(RegistrableConfig, ABC):
     registry_key: ClassVar[str] = Field(const=True, default="type")
 
+    app_config_path: Optional[Path] = None
     inactive_after_s: Optional[float] = None
     log_level: str = "INFO"
     task_queue_poll_interval_s: float = 1.0


### PR DESCRIPTION
# Changes

## `icij-worker`
### Added
- added `WorkerConfig.app_config_path: Optional[Path] = None` so that worker can load async app config from a path at startup. The `WorkerConfig` holds the worker related settings (async worker settings), while the app config holds the application settings (business logic configuration)
