### PR TITLE
chore: improve mp process handling

### DIFF
--- a/icij-worker/README.md
+++ b/icij-worker/README.md
@@ -25,8 +25,9 @@ def long_running_task(greeted: str) -> str:
 decorate your function with `ICIJApp` class and register a new task:
 
 ```python
+from icij_worker import AsyncApp
 
-my_app = ICIJApp(name="my_app")
+my_app = AsyncApp(name="my_app")
 
 @my_app.task
 def long_running_task(greeted: str) -> str:

--- a/icij-worker/icij_worker/backend/backend.py
+++ b/icij-worker/icij_worker/backend/backend.py
@@ -20,9 +20,6 @@ class WorkerBackend(str, Enum):
     # workers for IO based tasks
     MULTIPROCESSING = "multiprocessing"
 
-    # TODO: refactor this one to be a function rather than a cm coroutine a context
-    #  manager is no longer needed to run workers inside the HTTP server
-    @contextmanager
     def run(
         self,
         app: str,

--- a/icij-worker/icij_worker/backend/mp.py
+++ b/icij-worker/icij_worker/backend/mp.py
@@ -3,10 +3,16 @@ import logging
 import multiprocessing
 import os
 import signal
-import sys
-
+from concurrent.futures import (
+    CancelledError,
+    Future,
+    ProcessPoolExecutor,
+    as_completed,
+)
 from contextlib import contextmanager
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Set, Tuple
+
+import sys
 
 import icij_worker
 from icij_common.logging_utils import setup_loggers
@@ -28,15 +34,21 @@ def _mp_work_forever(
     app_deps_extras: Optional[Dict] = None,
 ):
     setup_loggers(["__main__", icij_worker.__name__])
-    if worker_extras is None:
-        worker_extras = dict()
-    if app_deps_extras is None:
-        app_deps_extras = dict()
-    # For multiprocessing, lifespan dependencies need to be run once per process
-    app = AsyncApp.load(app)
-    deps_cm = app.lifetime_dependencies(
-        worker_id=worker_id, worker_config=config, **app_deps_extras
-    )
+    try:
+        if worker_extras is None:
+            worker_extras = dict()
+        if app_deps_extras is None:
+            app_deps_extras = dict()
+        # For multiprocessing, lifespan dependencies need to be run once per process
+        app = AsyncApp.load(app)
+        deps_cm = app.lifetime_dependencies(
+            worker_id=worker_id, worker_config=config, **app_deps_extras
+        )
+    except BaseException as e:
+        msg = "Error occurred during app loading or dependency injection: %s"
+        logger.error(msg, e, exc_info=True)
+        raise e
+    # From now on, the deps_cm should have setup loggers, we can let it log errors
     worker = Worker.from_config(config, app=app, worker_id=worker_id, **worker_extras)
     # This is ugly, but we have to work around the fact that we can't use asyncio code
     # here
@@ -53,7 +65,7 @@ def _mp_work_forever(
 
 def signal_handler(sig_num, *_):
     logger.error(
-        "received %s, triggering process pool worker shutdown !",
+        "received %s, triggering process executor shutdown !",
         signal.Signals(sig_num).name,
     )
 
@@ -70,7 +82,7 @@ def _get_mp_async_runner(
     *,
     worker_extras: Optional[Dict] = None,
     app_deps_extras: Optional[Dict] = None,
-) -> Tuple[multiprocessing.Pool, List[Tuple[str, Callable[[], None]]]]:
+) -> Tuple[ProcessPoolExecutor, List[Tuple[str, Callable]]]:
     # This function is here to avoid code duplication, it will be removed
 
     # Here we set maxtasksperchild to 1. Each worker has a single never ending task
@@ -78,7 +90,7 @@ def _get_mp_async_runner(
     # maxtasksperchild=1 seems to help to terminate the worker pull
     # (cpython bug: https://github.com/python/cpython/pull/8009)
     mp_ctx = multiprocessing.get_context("spawn")
-    pool = mp_ctx.Pool(n_workers, maxtasksperchild=1)
+    executor = ProcessPoolExecutor(max_workers=n_workers, mp_context=mp_ctx)
     main_process_id = os.getpid()
     # TODO: make this a bit more informative be for instance adding the child process ID
     worker_ids = [f"worker-{main_process_id}-{i}" for i in range(n_workers)]
@@ -88,23 +100,25 @@ def _get_mp_async_runner(
         "worker_extras": worker_extras,
         "app_deps_extras": app_deps_extras,
     }
-    runners = []
+    futures = []
     for w_id in worker_ids:
         kwds.update({"worker_id": w_id})
-        runners.append(
-            (w_id, functools.partial(pool.apply_async, _mp_work_forever, kwds=kwds))
+        futures.append(
+            (w_id, functools.partial(executor.submit, _mp_work_forever, **kwds))
         )
-    return pool, runners
+    return executor, futures
 
 
 @contextmanager
-def _handle_pool_termination(pool: multiprocessing.Pool, handle_signals: bool):
+def _handle_executor_termination(
+    executor: ProcessPoolExecutor, futures: Set[Future], handle_signals: bool
+):
     try:
         yield
     except KeyboardInterrupt as e:
         if not handle_signals:
             logger.info(
-                "received %s, triggering process pool worker shutdown !",
+                "received %s, triggering process executor worker shutdown !",
                 KeyboardInterrupt.__name__,
             )
         else:
@@ -114,10 +128,16 @@ def _handle_pool_termination(pool: multiprocessing.Pool, handle_signals: bool):
             )
             raise RuntimeError(msg) from e
     finally:
+        msg = "Worker terminated by the executor"
+        exc = CancelledError(msg)
+        for f in futures:
+            if not f.done():
+                f.set_exception(exc)
+        for f in futures:
+            futures.discard(f)
         logger.info("Sending termination signal to workers (SIGTERM)...")
-        pool.terminate()
-        pool.join()
-        logger.info("Terminated worker pool !")
+        executor.shutdown(wait=False, cancel_futures=True)
+        logger.info("Terminated worker executor !")
 
 
 @contextmanager
@@ -131,19 +151,22 @@ def run_workers_with_multiprocessing_cm(
 ):
     if n_workers < 1:
         raise ValueError("n_workers must be >=1")
-    logger.info("Creating multiprocessing worker pool with %s workers", n_workers)
-    pool, worker_runners = _get_mp_async_runner(
+    logger.info("Creating multiprocessing executor with %s workers", n_workers)
+    executor, worker_runners = _get_mp_async_runner(
         app,
         config,
         n_workers,
         worker_extras=worker_extras,
         app_deps_extras=app_deps_extras,
     )
+    futures = set()
     for w_id, process_runner in worker_runners:
         logger.info("starting worker %s", w_id)
-        process_runner()
-    with _handle_pool_termination(pool, False):
-        yield
+        future = process_runner()
+        futures.add(future)
+    with _handle_executor_termination(executor, futures, True):
+        for _ in as_completed(futures):
+            pass
 
 
 def run_workers_with_multiprocessing(
@@ -156,8 +179,8 @@ def run_workers_with_multiprocessing(
 ):
     if n_workers < 1:
         raise ValueError("n_workers must be >=1")
-    logger.info("Creating multiprocessing worker pool with %s workers", n_workers)
-    pool, worker_runners = _get_mp_async_runner(
+    logger.info("Creating multiprocessing executor with %s workers", n_workers)
+    executor, worker_runners = _get_mp_async_runner(
         app,
         config,
         n_workers,
@@ -165,9 +188,12 @@ def run_workers_with_multiprocessing(
         app_deps_extras=app_deps_extras,
     )
     setup_main_process_signal_handlers()
-    tasks = []
+    futures = set()
     for w_id, process_runner in worker_runners:
         logger.info("starting worker %s", w_id)
-        tasks.append(process_runner())
-    with _handle_pool_termination(pool, True):
-        pass
+        future = process_runner()
+        futures.add(future)
+        future.add_done_callback(futures.discard)
+    with _handle_executor_termination(executor, futures, True):
+        for _ in as_completed(futures):
+            pass

--- a/icij-worker/pyproject.toml
+++ b/icij-worker/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "icij-worker"
-version = "0.2.5"
+version = "0.2.6"
 description = "Create asynchronous tasks from Python functions"
 authors = [
     "Clément Doumouro <cdoumouro@icij.org>",


### PR DESCRIPTION
# PR description

Revert mp worker handling by using `ProcessPoolExecutor` rather than `Pool`. Using a `ProcessPoolExecutor` offers a nicer interface to running process and in particular allows for nicer log handling, before the loggers correctly set their own loggers/


Using this implementation might restore the bug fixed in https://github.com/ICIJ/datashare-extension-neo4j/pull/132
However the new implementation takes care of cancelling each running future so that the executor can safely shutdown.

Indeed we previously missed that according to the [`ProcessPoolExecutor.shutdown` doc](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Executor.shutdown):
```
Regardless of the value of wait, the entire Python program will not exit until all pending futures are done executing.
```

# Changes

## `icij-worker`

### Changed
- swictched from `Pool` to `ProcessPoolExecutor` for the worker mp backend
