### PR TITLE
[⚠️ breaking]chore: align error format

### DIFF
--- a/icij-common/icij_common/neo4j/constants.py
+++ b/icij-common/icij_common/neo4j/constants.py
@@ -33,10 +33,13 @@ TASK_LOCK_TASK_ID = "taskId"
 TASK_LOCK_WORKER_ID = "workerId"
 
 TASK_ERROR_NODE = "_TaskError"
-TASK_ERROR_DETAIL = "detail"
+TASK_ERROR_DETAIL_DEPRECATED = "detail"  # use stacktrace
 TASK_ERROR_ID = "id"
+TASK_ERROR_MESSAGE = "message"
+TASK_ERROR_NAME = "name"
 TASK_ERROR_OCCURRED_AT = "occurredAt"
-TASK_ERROR_TITLE = "title"
+TASK_ERROR_STACKTRACE = "stacktrace"
+TASK_ERROR_TITLE_DEPRECATED = "title"  # use message
 
 TASK_ERROR_OCCURRED_TYPE = "_OCCURRED_DURING"
 

--- a/icij-worker/icij_worker/tests/test_task.py
+++ b/icij-worker/icij_worker/tests/test_task.py
@@ -6,6 +6,7 @@ import pytest
 from icij_worker.task import (
     PRECEDENCE,
     READY_STATES,
+    StacktraceItem,
     Task,
     TaskError,
     TaskEvent,
@@ -112,8 +113,13 @@ def test_precedence_sanity_check():
                 error=TaskError(
                     id="error-id",
                     task_id="task-id",
-                    title="some-error",
-                    detail="some details",
+                    name="some-error",
+                    message="some message",
+                    stacktrace=[
+                        StacktraceItem(
+                            name="SomeError", file="some details", lineno=666
+                        )
+                    ],
                     occurred_at=_ERROR_OCCURRED_AT,
                 ),
             ),
@@ -122,8 +128,13 @@ def test_precedence_sanity_check():
                 error=TaskError(
                     id="error-id",
                     task_id="task-id",
-                    title="some-error",
-                    detail="some details",
+                    name="some-error",
+                    message="some message",
+                    stacktrace=[
+                        StacktraceItem(
+                            name="SomeError", file="some details", lineno=666
+                        )
+                    ],
                     occurred_at=_ERROR_OCCURRED_AT,
                 ),
             ),
@@ -168,8 +179,13 @@ def test_precedence_sanity_check():
                 error=TaskError(
                     id="error-id",
                     task_id="task-id",
-                    title="some-error",
-                    detail="some details",
+                    name="some-error",
+                    message="some message",
+                    stacktrace=[
+                        StacktraceItem(
+                            name="SomeError", file="some details", lineno=666
+                        )
+                    ],
                     occurred_at=_ERROR_OCCURRED_AT,
                 ),
                 created_at=_ANOTHER_TIME,
@@ -193,8 +209,13 @@ def test_precedence_sanity_check():
                 error=TaskError(
                     id="error-id",
                     task_id="task-id",
-                    title="some-error",
-                    detail="some details",
+                    name="some-error",
+                    message="some message",
+                    stacktrace=[
+                        StacktraceItem(
+                            name="SomeError", file="some details", lineno=666
+                        )
+                    ],
                     occurred_at=_ERROR_OCCURRED_AT,
                 ),
                 created_at=_ANOTHER_TIME,
@@ -218,8 +239,13 @@ def test_precedence_sanity_check():
                 error=TaskError(
                     id="error-id",
                     task_id="task-id",
-                    title="some-error",
-                    detail="some details",
+                    name="some-error",
+                    message="some message",
+                    stacktrace=[
+                        StacktraceItem(
+                            name="SomeError", file="some details", lineno=666
+                        )
+                    ],
                     occurred_at=_ERROR_OCCURRED_AT,
                 ),
                 created_at=_ANOTHER_TIME,

--- a/icij-worker/icij_worker/tests/worker/test_amqp.py
+++ b/icij-worker/icij_worker/tests/worker/test_amqp.py
@@ -26,7 +26,7 @@ from icij_worker import (
     WorkerConfig,
 )
 from icij_worker.event_publisher.amqp import AMQPPublisher, Exchange, Routing
-from icij_worker.task import CancelledTaskEvent
+from icij_worker.task import CancelledTaskEvent, StacktraceItem
 from icij_worker.tests.conftest import (
     DEFAULT_VHOST,
     RABBITMQ_TEST_HOST,
@@ -375,8 +375,9 @@ async def test_publish_error(
     error = TaskError(
         id="error-id",
         task_id=task.id,
-        title="someErrorTitle",
-        detail="with_details",
+        name="someErrorTitle",
+        message="with_details",
+        stacktrace=[StacktraceItem(name="someErrorTitle", file="somefile", lineno=666)],
         occurred_at=datetime.now(),
     )
 

--- a/icij-worker/icij_worker/tests/worker/test_neo4j.py
+++ b/icij-worker/icij_worker/tests/worker/test_neo4j.py
@@ -19,7 +19,7 @@ from icij_worker import (
     TaskResult,
     TaskStatus,
 )
-from icij_worker.task import CancelledTaskEvent
+from icij_worker.task import CancelledTaskEvent, StacktraceItem
 
 
 @pytest.fixture(scope="function")
@@ -262,8 +262,11 @@ async def test_worker_save_error(populate_tasks: List[Task], worker: Neo4jWorker
         id="error-id",
         task_id=populate_tasks[0].id,
         project_id=project,
-        title="someErrorTitle",
-        detail="with_details",
+        name="someErrorTitle",
+        message="with_details",
+        stacktrace=[
+            StacktraceItem(name="someErrorTitle", file="with_details", lineno=666)
+        ],
         occurred_at=datetime.now(),
     )
 

--- a/icij-worker/icij_worker/utils/tests.py
+++ b/icij-worker/icij_worker/utils/tests.py
@@ -231,7 +231,7 @@ if _has_pytest:
             db = self._read()
             errors = db[self._error_collection]
             errors = errors.get(key, [])
-            errors = [TaskError(**err) for err in errors]
+            errors = [TaskError.parse_obj(err) for err in errors]
             return errors
 
         async def get_task_result(self, task_id: str) -> TaskResult:

--- a/icij-worker/icij_worker/worker/neo4j_.py
+++ b/icij-worker/icij_worker/worker/neo4j_.py
@@ -187,10 +187,12 @@ class Neo4jWorker(Worker, Neo4jEventPublisher):
                 " project's DB"
             )
         async with self._project_session(project_id) as sess:
+            error_props = error.dict(by_alias=True)
+            error_props["stacktrace"] = [
+                json.dumps(item) for item in error_props["stacktrace"]
+            ]
             await sess.execute_write(
-                _save_error_tx,
-                task_id=error.task_id,
-                error_props=error.dict(by_alias=True),
+                _save_error_tx, task_id=error.task_id, error_props=error_props
             )
 
     async def _acknowledge(self, task: Task, completed_at: datetime):

--- a/icij-worker/icij_worker/worker/worker.py
+++ b/icij-worker/icij_worker/worker/worker.py
@@ -323,7 +323,7 @@ class Worker(
 
     @final
     async def save_error(self, error: TaskError):
-        self.error('Task(id="%s"): %s\n%s', error.task_id, error.title, error.detail)
+        self.error('Task(id="%s"): %s\n%s', error.task_id, error.name, error.trace())
         # Save the error in the appropriate location
         self.debug('Task(id="%s") saving error', error.task_id)
         await self._save_error(error)


### PR DESCRIPTION
# PR description

This PR aligns task error format to be compatible with https://github.com/ICIJ/datashare/issues/1420

# Changes

## `icij-worker`

### Changed
- aligned task errors with to the java code base
- created a migration script for existing neo4j errors

# Notes
⚠️ breaking PR:
- will require a breaking bump
- migration of existing errors