### PR TITLE
⚠️ chore: remove project 

### DIFF
--- a/icij-common/README.md
+++ b/icij-common/README.md
@@ -6,7 +6,7 @@
 
 - neo4j test utils (useful `pytest` fixtures)
 - lightweight migration lib
-- split of ICIJ's project across neo4j DBs
+- handles enterprise support and multiple neo4j DBs
 
 ## `logging`
 

--- a/icij-common/icij_common/neo4j/constants.py
+++ b/icij-common/icij_common/neo4j/constants.py
@@ -1,13 +1,16 @@
-PROJECT_REGISTRY_DB = "datashare-project-registry"
+# Should be DB, but week keep it like this to avoid migrating the registry
+DATABASE_REGISTRY_DB = "datashare-project-registry"
 
-PROJECT_RUNS_MIGRATION = "_RUNS"
-PROJECT_NAME = "name"
-PROJECT_NODE = "_Project"
+DATABASE_RUNS_MIGRATION = "_RUNS"
+DATABASE_NAME = "name"
+# Should be DB, but week keep it like this to avoid migrating the registry
+DATABASE_NODE = "_Project"
 
 MIGRATION_COMPLETED = "completed"
 MIGRATION_LABEL = "label"
 MIGRATION_NODE = "_Migration"
-MIGRATION_PROJECT = "project"
+# Should be DB, but week keep it like this to avoid migrating the registry
+MIGRATION_DB = "project"
 MIGRATION_STARTED = "started"
 MIGRATION_STATUS = "status"
 MIGRATION_VERSION = "version"

--- a/icij-common/icij_common/neo4j/db.py
+++ b/icij-common/icij_common/neo4j/db.py
@@ -9,11 +9,11 @@ import neo4j
 
 from icij_common.neo4j.constants import (
     MIGRATION_NODE,
-    MIGRATION_PROJECT,
+    MIGRATION_DB,
     MIGRATION_VERSION,
-    PROJECT_NAME,
-    PROJECT_NODE,
-    PROJECT_REGISTRY_DB,
+    DATABASE_NAME,
+    DATABASE_NODE,
+    DATABASE_REGISTRY_DB,
 )
 from icij_common.pydantic_utils import ICIJModel
 
@@ -28,103 +28,105 @@ _COMPONENTS_QUERY = """CALL dbms.components() YIELD versions, edition
 RETURN versions, edition"""
 
 
-class Project(ICIJModel):
+class Database(ICIJModel):
     name: str
 
     @classmethod
-    def from_neo4j(cls, record: neo4j.Record, key="project") -> Project:
-        project = dict(record.value(key))
-        return Project(**project)
+    def from_neo4j(cls, record: neo4j.Record, key="db") -> Database:
+        db = dict(record.value(key))
+        return Database(**db)
 
 
-async def create_project_registry_db(neo4j_driver: neo4j.AsyncDriver):
+async def create_databases_registry_db(neo4j_driver: neo4j.AsyncDriver):
     if await is_enterprise(neo4j_driver):
-        logger.info("Creating project registry DB...")
+        logger.info("Creating databases registry DB...")
         query = "CREATE DATABASE $registry_db IF NOT EXISTS"
-        await neo4j_driver.execute_query(query, registry_db=PROJECT_REGISTRY_DB)
+        await neo4j_driver.execute_query(query, registry_db=DATABASE_REGISTRY_DB)
     else:
         logger.info("Using default db as registry DB !")
 
 
-async def projects_tx(tx: neo4j.AsyncTransaction) -> List[Project]:
-    query = f"MATCH (project:{PROJECT_NODE}) RETURN project"
+async def databases_tx(tx: neo4j.AsyncTransaction) -> List[Database]:
+    query = f"MATCH (db:{DATABASE_NODE}) RETURN db"
     res = await tx.run(query)
-    projects = [Project.from_neo4j(p) async for p in res]
-    return projects
+    dbs = [Database.from_neo4j(p) async for p in res]
+    return dbs
 
 
-async def create_project_db(neo4j_driver: neo4j.AsyncDriver, project: str):
+async def create_db(neo4j_driver: neo4j.AsyncDriver, db: str):
     if await is_enterprise(neo4j_driver):
-        db_name = await project_db(neo4j_driver, project=project)
+        db = await db_name(neo4j_driver, db=db)
         query = "CREATE DATABASE $db_name IF NOT EXISTS"
-        await neo4j_driver.execute_query(query, db_name=db_name)
+        await neo4j_driver.execute_query(query, db_name=db)
 
 
-async def add_project_support_migration_tx(tx: neo4j.AsyncTransaction):
-    await create_project_unique_name_constraint_tx(tx)
-    await create_migration_unique_project_and_version_constraint_tx(tx)
+async def add_multidatabase_support_migration_tx(tx: neo4j.AsyncTransaction):
+    await create_database_unique_name_constraint_tx(tx)
+    await create_migration_unique_database_and_version_constraint_tx(tx)
 
 
-async def create_project_unique_name_constraint_tx(tx: neo4j.AsyncTransaction):
+async def create_database_unique_name_constraint_tx(tx: neo4j.AsyncTransaction):
+    # TODO: rename that into constraint_database_unique_name
     constraint_query = f"""CREATE CONSTRAINT constraint_project_unique_name
 IF NOT EXISTS
-FOR (p:{PROJECT_NODE})
-REQUIRE (p.{PROJECT_NAME}) IS UNIQUE
+FOR (p:{DATABASE_NODE})
+REQUIRE (p.{DATABASE_NAME}) IS UNIQUE
 """
     await tx.run(constraint_query)
 
 
-async def create_migration_unique_project_and_version_constraint_tx(
+async def create_migration_unique_database_and_version_constraint_tx(
     tx: neo4j.AsyncTransaction,
 ):
+    # TODO: rename that into constraint_migration_unique_database_and_version
     constraint_query = f"""CREATE CONSTRAINT
      constraint_migration_unique_project_and_version
 IF NOT EXISTS 
 FOR (m:{MIGRATION_NODE})
-REQUIRE (m.{MIGRATION_VERSION}, m.{MIGRATION_PROJECT}) IS UNIQUE
+REQUIRE (m.{MIGRATION_VERSION}, m.{MIGRATION_DB}) IS UNIQUE
 """
     await tx.run(constraint_query)
 
 
-async def create_project_tx(
+async def create_database_tx(
     tx: neo4j.AsyncTransaction, name: str
-) -> Tuple[Project, bool]:
-    if name == PROJECT_REGISTRY_DB:
+) -> Tuple[Database, bool]:
+    if name == DATABASE_REGISTRY_DB:
         raise ValueError(
-            f'Bad luck, name "{PROJECT_REGISTRY_DB}" is reserved for internal use.'
-            f" Can't initialize project"
+            f'Bad luck, name "{DATABASE_REGISTRY_DB}" is reserved for internal use.'
+            f" Can't initialize database"
         )
-    query = f"""MERGE (project:{PROJECT_NODE} {{ {PROJECT_NAME}: $name }})
-RETURN project"""
+    query = f"""MERGE (db:{DATABASE_NODE} {{ {DATABASE_NAME}: $name }})
+RETURN db"""
     res = await tx.run(query, name=name)
     rec = await res.single()
     summary = await res.consume()
     existed = summary.counters.nodes_created == 0
-    project = Project.from_neo4j(rec)
-    return project, existed
+    database = Database.from_neo4j(rec)
+    return database, existed
 
 
-async def project_registry_db(neo4j_driver: neo4j.AsyncDriver) -> str:
+async def database_registry_db(neo4j_driver: neo4j.AsyncDriver) -> str:
     if await is_enterprise(neo4j_driver):
-        return PROJECT_REGISTRY_DB
+        return DATABASE_REGISTRY_DB
     return NEO4J_COMMUNITY_DB
 
 
-async def project_db(neo4j_driver: neo4j.AsyncDriver, project: str) -> str:
+async def db_name(neo4j_driver: neo4j.AsyncDriver, db: str) -> str:
     if await is_enterprise(neo4j_driver):
-        return project
+        return db
     return NEO4J_COMMUNITY_DB
 
 
-def project_index(project: str) -> str:
-    return project
+def databases_index(db: str) -> str:
+    return db
 
 
 @asynccontextmanager
-async def project_db_session(
-    neo4j_driver: neo4j.AsyncDriver, project: str
+async def db_specific_session(
+    neo4j_driver: neo4j.AsyncDriver, db: str
 ) -> AsyncGenerator[neo4j.AsyncSession, None]:
-    db = await project_db(neo4j_driver, project)
+    db = await db_name(neo4j_driver, db)
     sess_ctx = neo4j_driver.session(database=db)
     async with sess_ctx as sess:
         yield sess
@@ -132,7 +134,7 @@ async def project_db_session(
 
 @asynccontextmanager
 async def registry_db_session(neo4j_driver: neo4j.AsyncDriver) -> neo4j.AsyncSession:
-    session = neo4j_driver.session(database=await project_registry_db(neo4j_driver))
+    session = neo4j_driver.session(database=await database_registry_db(neo4j_driver))
     async with session as sess:
         yield sess
 

--- a/icij-common/icij_common/neo4j/test_utils.py
+++ b/icij-common/icij_common/neo4j/test_utils.py
@@ -7,7 +7,7 @@ import pytest
 from neo4j import AsyncGraphDatabase
 
 import icij_common
-from icij_common.neo4j.projects import NEO4J_COMMUNITY_DB
+from icij_common.neo4j.db import NEO4J_COMMUNITY_DB
 
 NEO4J_TEST_PORT = 7688
 NEO4J_TEST_USER = "neo4j"
@@ -92,14 +92,14 @@ async def mocked_is_enterprise(_: neo4j.AsyncDriver) -> bool:
 
 
 @contextlib.asynccontextmanager
-async def _mocked_project_db_session(
-    neo4j_driver: neo4j.AsyncDriver, project: str  # pylint: disable=unused-argument
+async def _mocked_db_specific_session(
+    neo4j_driver: neo4j.AsyncDriver, db: str  # pylint: disable=unused-argument
 ) -> neo4j.AsyncSession:
     async with neo4j_driver.session(database=NEO4J_COMMUNITY_DB) as sess:
         yield sess
 
 
-async def _mocked_project_registry_db(
+async def _mocked_db_registry_db(
     neo4j_driver: neo4j.AsyncDriver,  # pylint: disable=unused-argument
 ) -> str:
     return NEO4J_COMMUNITY_DB
@@ -112,18 +112,12 @@ def mock_enterprise(monkeypatch):
 
 def mock_enterprise_(monkeypatch):
     monkeypatch.setattr(
-        icij_common.neo4j.projects, "project_db_session", _mocked_project_db_session
+        icij_common.neo4j.db, "db_specific_session", _mocked_db_specific_session
     )
     monkeypatch.setattr(
-        icij_common.neo4j.migrate,
-        "project_db_session",
-        _mocked_project_db_session,
+        icij_common.neo4j.migrate, "db_specific_session", _mocked_db_specific_session
     )
     monkeypatch.setattr(
-        icij_common.neo4j.projects,
-        "project_registry_db",
-        _mocked_project_registry_db,
+        icij_common.neo4j.db, "database_registry_db", _mocked_db_registry_db
     )
-    monkeypatch.setattr(
-        icij_common.neo4j.projects, "is_enterprise", mocked_is_enterprise
-    )
+    monkeypatch.setattr(icij_common.neo4j.db, "is_enterprise", mocked_is_enterprise)

--- a/icij-common/icij_common/test_utils.py
+++ b/icij-common/icij_common/test_utils.py
@@ -8,7 +8,7 @@ from typing import Awaitable, Callable, Optional
 
 import pytest
 
-TEST_PROJECT = "test_project"
+TEST_DB = "test_db"
 
 
 def true_after(

--- a/icij-common/icij_common/tests/neo4j/test_projects.py
+++ b/icij-common/icij_common/tests/neo4j/test_projects.py
@@ -1,9 +1,9 @@
 from unittest.mock import AsyncMock
 
-from icij_common.neo4j.projects import create_project_registry_db
+from icij_common.neo4j.db import create_databases_registry_db
 
 
-async def test_should_create_project_registry_db_with_enterprise_distribution(
+async def test_should_create_databases_registry_db_with_enterprise_distribution(
     mock_enterprise,
 ):
     # pylint: disable=unused-argument
@@ -11,7 +11,7 @@ async def test_should_create_project_registry_db_with_enterprise_distribution(
     mocked_driver = AsyncMock()
 
     # When
-    await create_project_registry_db(mocked_driver)
+    await create_databases_registry_db(mocked_driver)
 
     # Then
     mocked_driver.execute_query.assert_called_once_with(

--- a/icij-worker/icij_worker/event_publisher/event_publisher.py
+++ b/icij-worker/icij_worker/event_publisher/event_publisher.py
@@ -1,13 +1,12 @@
 from abc import ABC, abstractmethod
 from typing import final
 
-from icij_worker import Task, TaskEvent
+from icij_worker import TaskEvent
 
 
 class EventPublisher(ABC):
     @final
-    async def publish_event(self, event: TaskEvent, task: Task):
-        event = event.with_project_id(task)
+    async def publish_event(self, event: TaskEvent):
         await self._publish_event(event)
 
     @abstractmethod

--- a/icij-worker/icij_worker/tests/event_publisher/test_ampq.py
+++ b/icij-worker/icij_worker/tests/event_publisher/test_ampq.py
@@ -2,7 +2,6 @@ import pytest
 from aio_pika import ExchangeType, connect_robust
 from aiormq import ChannelNotFoundEntity
 
-from icij_common.pydantic_utils import safe_copy
 from icij_worker import Task, TaskEvent, TaskStatus
 from icij_worker.event_publisher.amqp import (
     AMQPPublisher,
@@ -46,7 +45,7 @@ async def test_publish_event(rabbit_mq: str, hello_world_task: Task):
 
     # When
     async with publisher:
-        await publisher.publish_event(event, task)
+        await publisher.publish_event(event)
 
     # Then
     connection = await connect_robust(url=broker_url)
@@ -56,8 +55,7 @@ async def test_publish_event(rabbit_mq: str, hello_world_task: Task):
         async for message in messages:
             received_event = TaskEvent.parse_raw(message.body)
             break
-    expected = safe_copy(event, update={"project_id": task.project_id})
-    assert received_event == expected
+    assert received_event == event
 
 
 async def test_publisher_not_create_and_bind_exchanges_and_queues(rabbit_mq: str):

--- a/icij-worker/icij_worker/tests/test_task.py
+++ b/icij-worker/icij_worker/tests/test_task.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 from typing import Optional
 

--- a/icij-worker/icij_worker/tests/worker/test_amqp.py
+++ b/icij-worker/icij_worker/tests/worker/test_amqp.py
@@ -10,11 +10,7 @@ from aio_pika import ExchangeType, Message, connect_robust
 from pydantic import Field
 
 from icij_common.pydantic_utils import safe_copy
-from icij_common.test_utils import (
-    TEST_PROJECT,
-    async_true_after,
-    fail_if_exception,
-)
+from icij_common.test_utils import async_true_after, fail_if_exception
 from icij_worker import (
     AsyncApp,
     Task,
@@ -350,7 +346,7 @@ async def test_publish_event(
     event = TaskEvent(task_id=task.id, progress=50.0)
     # When
     async with amqp_worker:
-        await amqp_worker.publish_event(event, task)
+        await amqp_worker.publish_event(event)
 
         # Then
         connection = await connect_robust(url=broker_url)
@@ -361,8 +357,7 @@ async def test_publish_event(
             async for message in messages:
                 received_event = TaskEvent.parse_raw(message.body)
                 break
-        expected = safe_copy(event, update={"project_id": TEST_PROJECT})
-        assert received_event == expected
+        assert received_event == event
 
 
 async def test_publish_error(


### PR DESCRIPTION
# PR description

This removes the `project` concept from the API.
The project notion was inherited from Datashare, `icij-common` and `icij-worker` should be agnostic to it.



# Changes

## `icij-common`
### Changed
- remove the project from the lib and replace it with the db concept. Previously for neo4j the project was needed for the neo4j enterprise support where each project was mapped to a different DB. The lib now directly exposes the db concept and the user is responsible to map each potential project to its DB.

## `icij-common`
### Changed
- removed the `project_id` attribute from `Task`, `TaskError`, `TaskResult`, `TaskEvent`, `CancelledTaskEvent`. The `TaskManager` and worker implementations are now responsible to keep track of different message routing (for instance for neo4j, they must keep track of which DB the message was consumed to make sure to send related messages to the same DB)



# Notes
- some project naming in `icij-common` was left to avoid the painful migration of the project/db registry DB in charge of recording state of each DB and their migrations