### PR TITLE
chore: use a single exchange for results and errors

### DIFF
--- a/icij-worker/icij_worker/constants.py
+++ b/icij-worker/icij_worker/constants.py
@@ -1,11 +1,3 @@
-AMQP_ERRORS_X = "exchangeMainErrors"
-AMQP_ERRORS_QUEUE = "TASK_ERROR"
-AMQP_ERRORS_ROUTING_KEY = "routingKeyMainErrors"
-
-AMQP_ERRORS_DL_X = "exchangeDLQTaskErrors"
-AMQP_ERRORS_DL_QUEUE = "TASK_ERROR_DLQ"
-AMQP_ERRORS_DL_ROUTING_KEY = "routingKeyDLQTaskErrors"
-
 AMQP_EVENTS_X = "exchangeMainEvents"
 AMQP_EVENTS_QUEUE = "EVENT"
 AMQP_EVENTS_ROUTING_KEY = "routingKeyMainEvents"

--- a/icij-worker/icij_worker/tests/task_manager/test_amqp.py
+++ b/icij-worker/icij_worker/tests/task_manager/test_amqp.py
@@ -179,9 +179,9 @@ async def test_task_manager_should_consume_errors(
     message = error.json().encode()
     channel = task_manager.channel
     # When
-    exchange = await channel.get_exchange("exchangeMainErrors")
+    exchange = await channel.get_exchange("exchangeTaskResults")
     message = Message(message, delivery_mode=DeliveryMode.PERSISTENT, app_id="test-app")
-    await exchange.publish(message, "routingKeyMainErrors")
+    await exchange.publish(message, "routingKeyMainTaskResults")
     # Then
     consume_timeout = 2.0
     msg = f"Failed to consume error in less than {consume_timeout}"

--- a/icij-worker/icij_worker/utils/amqp.py
+++ b/icij-worker/icij_worker/utils/amqp.py
@@ -16,12 +16,6 @@ from pamqp.commands import Basic
 
 from icij_worker import Message
 from icij_worker.constants import (
-    AMQP_ERRORS_DL_QUEUE,
-    AMQP_ERRORS_DL_ROUTING_KEY,
-    AMQP_ERRORS_DL_X,
-    AMQP_ERRORS_QUEUE,
-    AMQP_ERRORS_ROUTING_KEY,
-    AMQP_ERRORS_X,
     AMQP_EVENTS_QUEUE,
     AMQP_EVENTS_ROUTING_KEY,
     AMQP_EVENTS_X,
@@ -131,7 +125,7 @@ class AMQPMixin:
 
     @classmethod
     @lru_cache(maxsize=1)
-    def res_routing(cls) -> Routing:
+    def res_and_err_routing(cls) -> Routing:
         return Routing(
             exchange=Exchange(name=AMQP_RESULTS_X, type=ExchangeType.DIRECT),
             routing_key=AMQP_RESULTS_ROUTING_KEY,
@@ -140,20 +134,6 @@ class AMQPMixin:
                 exchange=Exchange(name=AMQP_RESULTS_DL_X, type=ExchangeType.DIRECT),
                 routing_key=AMQP_RESULTS_DL_ROUTING_KEY,
                 queue_name=AMQP_RESULTS_DL_QUEUE,
-            ),
-        )
-
-    @classmethod
-    @lru_cache(maxsize=1)
-    def err_routing(cls) -> Routing:
-        return Routing(
-            exchange=Exchange(name=AMQP_ERRORS_X, type=ExchangeType.DIRECT),
-            routing_key=AMQP_ERRORS_ROUTING_KEY,
-            queue_name=AMQP_ERRORS_QUEUE,
-            dead_letter_routing=Routing(
-                exchange=Exchange(name=AMQP_ERRORS_DL_X, type=ExchangeType.DIRECT),
-                routing_key=AMQP_ERRORS_DL_ROUTING_KEY,
-                queue_name=AMQP_ERRORS_DL_QUEUE,
             ),
         )
 


### PR DESCRIPTION
# Changes

## `icij-worker`

### Added
- use a share exchange for results and errors in AMQP
