### PR TITLE
fix: amqp worker event queue creation

### DIFF
--- a/icij-worker/icij_worker/task_manager/amqp.py
+++ b/icij-worker/icij_worker/task_manager/amqp.py
@@ -190,6 +190,7 @@ class AMQPTaskManager(TaskManager, AMQPMixin):
             }
         await self._create_routing(
             task_routing,
+            declare_exchanges=True,
             declare_queues=True,
             durable_queues=True,
             queue_args=task_queue_args,
@@ -197,7 +198,10 @@ class AMQPTaskManager(TaskManager, AMQPMixin):
         for routing in self._other_routings:
             logger.debug("(re)declaring routing %s...", routing)
             await self._create_routing(
-                routing, declare_queues=True, durable_queues=True
+                routing,
+                declare_exchanges=True,
+                declare_queues=True,
+                durable_queues=True,
             )
         self._task_x = await self._channel.get_exchange(
             self.default_task_routing().exchange.name, ensure=True

--- a/icij-worker/icij_worker/worker/amqp.py
+++ b/icij-worker/icij_worker/worker/amqp.py
@@ -9,7 +9,6 @@ from aio_pika import RobustQueue
 from aio_pika.abc import (
     AbstractIncomingMessage,
     AbstractQueueIterator,
-    AbstractRobustChannel,
     AbstractRobustConnection,
 )
 from pydantic import Field
@@ -104,7 +103,6 @@ class AMQPWorker(Worker, AMQPMixin):
         )
 
         self._publisher: Optional[AMQPPublisher] = None
-        self._channel_: Optional[AbstractRobustChannel] = None
         self._connection_: Optional[AbstractRobustConnection] = None
         self._task_queue_: Optional[RobustQueue] = None
         self._task_queue_iterator: Optional[AbstractQueueIterator] = None


### PR DESCRIPTION
# Bug description
In the test codebase for the `AMQPWorker`, the worker was declaring all queues and exchanges by itself to make the test writing easier.

In practice it's not the case.

# Changes

## `icij-worker`

### Added
- added a test to test the connection workflow for `AMQPWorker`

### Fixed
- fixed the  `AMQPWorker` worker queue event creation by the worker itself

