### PR TITLE
feature: early ack

### DIFF
--- a/icij-common/icij_common/logging_utils.py
+++ b/icij-common/icij_common/logging_utils.py
@@ -43,6 +43,10 @@ class LogWithNameMixin(ABC):
         self._logger.error(msg, *args, **kwargs)
 
     @final
+    def exception(self, msg, *args, **kwargs):
+        self._logger.exception(msg, *args, **kwargs)
+
+    @final
     def warning(self, msg, *args, **kwargs):
         self._logger.warning(msg, *args, **kwargs)
 

--- a/icij-common/icij_common/pydantic_utils.py
+++ b/icij-common/icij_common/pydantic_utils.py
@@ -7,7 +7,7 @@ from pathlib import PurePath
 from types import GeneratorType
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union, cast
 
-from pydantic import BaseModel
+from pydantic import BaseModel, BaseSettings, Extra
 from pydantic.fields import FieldInfo
 from pydantic.json import ENCODERS_BY_TYPE
 
@@ -51,10 +51,13 @@ def safe_copy(obj: BaseModel, **kwargs):
 class ICIJModel(BaseModel):
     class Config:
         allow_mutation = False
-        extra = "forbid"
+        extra = Extra.forbid
         allow_population_by_field_name = True
         keep_untouched = (cached_property,)
         use_enum_values = True
+
+
+class ICIJSettings(BaseSettings): ...  # pylint: disable=multiple-statements
 
 
 def get_field_default_value(attr: FieldInfo):

--- a/icij-worker/icij_worker/app.py
+++ b/icij-worker/icij_worker/app.py
@@ -12,6 +12,7 @@ from icij_worker.namespacing import Namespacing
 from icij_worker.typing_ import Dependency
 from icij_worker.utils import run_deps
 from icij_worker.utils.imports import import_variable
+from icij_worker.worker.config import AsyncAppConfig
 
 logger = logging.getLogger(__name__)
 
@@ -27,10 +28,14 @@ class AsyncApp:
     def __init__(
         self,
         name: str,
+        config: AsyncAppConfig = None,
         dependencies: Optional[List[Dependency]] = None,
         namespacing: Optional[Namespacing] = None,
     ):
         self._name = name
+        if config is None:
+            config = AsyncAppConfig()  # This will load from the env
+        self._config = config
         self._registry = dict()
         if dependencies is None:
             dependencies = []
@@ -38,6 +43,10 @@ class AsyncApp:
         if namespacing is None:
             namespacing = Namespacing()
         self._namespacing = namespacing
+
+    @property
+    def config(self) -> AsyncAppConfig:
+        return self._config
 
     @property
     def registry(self) -> Dict[str, RegisteredTask]:

--- a/icij-worker/icij_worker/backend/mp.py
+++ b/icij-worker/icij_worker/backend/mp.py
@@ -60,7 +60,7 @@ def _mp_work_forever(
         )
     except BaseException as e:
         msg = "Error occurred during app loading or dependency injection: %s"
-        logger.error(msg, e, exc_info=True)
+        logger.exception(msg, e)
         raise e
     try:
         worker.work_forever()
@@ -71,7 +71,7 @@ def _mp_work_forever(
 
 
 def signal_handler(sig_num, *_):
-    logger.error(
+    logger.exception(
         "received %s, triggering process executor shutdown !",
         signal.Signals(sig_num).name,
     )

--- a/icij-worker/icij_worker/exceptions.py
+++ b/icij-worker/icij_worker/exceptions.py
@@ -24,8 +24,11 @@ class UnknownTask(ICIJWorkerError, ValueError):
 
 
 class TaskQueueIsFull(ICIJWorkerError, RuntimeError):
-    def __init__(self, max_queue_size: int):
-        super().__init__(f"task queue is full ({max_queue_size}/{max_queue_size})")
+    def __init__(self, max_queue_size: Optional[int]):
+        msg = "task queue is full"
+        if max_queue_size is not None:
+            msg += f" ({max_queue_size}/{max_queue_size})"
+        super().__init__(msg)
 
 
 class TaskAlreadyCancelled(ICIJWorkerError, RuntimeError):

--- a/icij-worker/icij_worker/task_manager/neo4j_.py
+++ b/icij-worker/icij_worker/task_manager/neo4j_.py
@@ -23,12 +23,11 @@ class Neo4JTaskManager(TaskManager, Neo4jStorage):
         self,
         app_name: str,
         driver: neo4j.AsyncDriver,
-        max_queue_size: int,
+        max_task_queue_size: int,
         namespacing: Optional[Namespacing] = None,
     ) -> None:
-        super().__init__(app_name, namespacing)
+        super().__init__(app_name, max_task_queue_size, namespacing)
         super(TaskManager, self).__init__(driver)
-        self._max_queue_size = max_queue_size
 
     @property
     def driver(self) -> neo4j.AsyncDriver:
@@ -39,7 +38,9 @@ class Neo4JTaskManager(TaskManager, Neo4jStorage):
         db = await self._get_task_db(task_id=task.id)
         async with self._db_session(db) as sess:
             return await sess.execute_write(
-                _enqueue_task_tx, task_id=task.id, max_queue_size=self._max_queue_size
+                _enqueue_task_tx,
+                task_id=task.id,
+                max_queue_size=self._max_task_queue_size,
             )
 
     async def _cancel(self, *, task_id: str, requeue: bool):

--- a/icij-worker/icij_worker/tests/event_publisher/test_ampq.py
+++ b/icij-worker/icij_worker/tests/event_publisher/test_ampq.py
@@ -2,7 +2,7 @@ import pytest
 from aio_pika import ExchangeType, connect_robust
 from aiormq import ChannelNotFoundEntity
 
-from icij_worker import Task, TaskEvent, TaskState
+from icij_worker import Task, TaskEvent
 from icij_worker.event_publisher.amqp import (
     AMQPPublisher,
 )
@@ -39,7 +39,7 @@ async def test_publish_event(rabbit_mq: str, hello_world_task: Task):
     publisher = TestableAMQPPublisher(
         broker_url=broker_url, connection_timeout_s=2, reconnection_wait_s=1
     )
-    event = ProgressEvent(task_id=task.id, state=TaskState.RUNNING, progress=0.0)
+    event = ProgressEvent(task_id=task.id, progress=0.0)
 
     # When
     async with publisher:

--- a/icij-worker/icij_worker/tests/event_publisher/test_neo4j.py
+++ b/icij-worker/icij_worker/tests/event_publisher/test_neo4j.py
@@ -32,7 +32,7 @@ def publisher(neo4j_async_app_driver: neo4j.AsyncDriver) -> Neo4jEventPublisher:
     "event,task_update",
     [
         (
-            ProgressEvent(task_id="task-0", progress=0.66, state=TaskState.RUNNING),
+            ProgressEvent(task_id="task-0", progress=0.66),
             TaskUpdate(progress=0.66),
         ),
         (
@@ -53,7 +53,7 @@ def publisher(neo4j_async_app_driver: neo4j.AsyncDriver) -> Neo4jEventPublisher:
                 ),
                 state=TaskState.QUEUED,
             ),
-            TaskUpdate(retries=2),
+            TaskUpdate(retries=2, progress=0.0),
         ),
     ],
 )
@@ -160,7 +160,7 @@ RETURN task"""
     task = await task_manager.get_task(task_id=task_id)
     assert task.state is TaskState.DONE
 
-    event = ProgressEvent(task_id=task.id, state=TaskState.RUNNING, progress=0.0)
+    event = ProgressEvent(task_id=task.id, progress=0.0)
 
     # When
     await publisher.publish_event(event)

--- a/icij-worker/icij_worker/tests/task_storage/test_neo4j.py
+++ b/icij-worker/icij_worker/tests/task_storage/test_neo4j.py
@@ -201,7 +201,9 @@ async def test_migrate_task_inputs_to_arguments_v0_tx(
 ):
     # pylint: disable=unused-argument
     # Given
-    task_manager = Neo4JTaskManager("test-app", neo4j_test_driver, max_queue_size=10)
+    task_manager = Neo4JTaskManager(
+        "test-app", neo4j_test_driver, max_task_queue_size=10
+    )
     driver = task_manager.driver
     # When
     async with driver.session() as session:
@@ -246,7 +248,7 @@ async def test_migrate_task_type_to_name_v0_tx(
 ):
     # Given
     driver = neo4j_test_driver
-    task_manager = Neo4JTaskManager("test-app", driver, max_queue_size=10)
+    task_manager = Neo4JTaskManager("test-app", driver, max_task_queue_size=10)
     create_legacy_index = f"""CREATE INDEX task_type_index
 FOR (task:_Task) 
 ON (task.{TASK_TYPE_DEPRECATED})"""

--- a/icij-worker/icij_worker/tests/worker/conftest.py
+++ b/icij-worker/icij_worker/tests/worker/conftest.py
@@ -31,13 +31,17 @@ def test_app() -> AsyncApp:
     return make_app()
 
 
-@pytest.fixture(scope="function")
-def mock_worker(test_async_app: AsyncApp, mock_db: Path, request) -> MockWorker:
-    namespace = getattr(request, "param", None)
+@pytest.fixture(
+    scope="function",
+    params=[{"app": "test_async_app"}, {"app": "test_async_app_late"}],
+)
+def mock_worker(mock_db: Path, request) -> MockWorker:
+    param = getattr(request, "param", dict())
+    app = request.getfixturevalue(param.get("app"))
     worker = MockWorker(
-        test_async_app,
+        app,
         "test-worker",
-        namespace=namespace,
+        namespace=param.get("namespace"),
         db_path=mock_db,
         task_queue_poll_interval_s=0.1,
         teardown_dependencies=False,

--- a/icij-worker/icij_worker/tests/worker/test_amqp.py
+++ b/icij-worker/icij_worker/tests/worker/test_amqp.py
@@ -359,7 +359,7 @@ async def test_worker_negatively_acknowledge(
             expected = functools.partial(
                 _assert_has_size, queue_name=task_routing.queue_name, n=2
             )
-        timeout = 5  # Stats can take long to refresh...
+        timeout = 10  # Stats can take long to refresh...
         failure = f"Failed to requeue job in less than {timeout} seconds."
         assert await async_true_after(expected, after_s=timeout), failure
 

--- a/icij-worker/icij_worker/utils/dependencies.py
+++ b/icij-worker/icij_worker/utils/dependencies.py
@@ -21,7 +21,7 @@ def _log_exception_and_continue():
     try:
         yield
     except Exception as exc:  # pylint: disable=broad-exception-caught
-        logger.error("Exception %s occurred ", exc, exc_info=True)
+        logger.exception("Exception %s occurred ", exc)
 
 
 @asynccontextmanager
@@ -44,9 +44,7 @@ async def run_deps(
         yield
     except Exception as e:  # pylint: disable=broad-exception-caught
         original_ex = e
-        logger.error(
-            "Exception occurred while opening dependency: %s", e, exc_info=True
-        )
+        logger.exception("Exception occurred while opening dependency: %s", e)
     finally:
         to_raise = []
         if original_ex is not None:
@@ -69,5 +67,5 @@ async def run_deps(
         logger.debug("Rolled back all dependencies for %s !", ctx)
         if to_raise:
             for e in to_raise:
-                logger.error("Error while handling dependencies %s!", e)
+                logger.exception("Error while handling dependencies %s!", e)
             raise RuntimeError(to_raise)

--- a/icij-worker/icij_worker/utils/registrable.py
+++ b/icij-worker/icij_worker/utils/registrable.py
@@ -19,8 +19,9 @@ from typing import (
     cast,
 )
 
-from pydantic import BaseSettings, Field
+from pydantic import Field
 
+from icij_common.pydantic_utils import ICIJSettings
 from icij_worker.utils import FromConfig
 from icij_worker.utils.from_config import T
 from icij_worker.utils.imports import VariableNotFound, import_variable
@@ -140,7 +141,7 @@ If your registered class comes from custom code, you'll need to import the\
         raise ValueError("registration inconsistancy")
 
 
-class RegistrableConfig(BaseSettings, RegistrableMixin):
+class RegistrableConfig(ICIJSettings, RegistrableMixin):
     registry_key: ClassVar[str] = Field(const=True, default="name")
 
     @classmethod

--- a/icij-worker/icij_worker/worker/config.py
+++ b/icij-worker/icij_worker/worker/config.py
@@ -7,13 +7,22 @@ from typing import ClassVar, Optional, Union
 from pydantic import Field, Protocol
 from pydantic.parse import load_file
 
+from icij_common.pydantic_utils import ICIJSettings
 from icij_worker.utils.registrable import RegistrableConfig
+
+
+class AsyncAppConfig(ICIJSettings):
+    late_ack: bool = False
+
+    class Config:
+        env_prefix = "ICIJ_APP_"
 
 
 class WorkerConfig(RegistrableConfig, ABC):
     registry_key: ClassVar[str] = Field(const=True, default="type")
 
-    app_config_path: Optional[Path] = None
+    # TODO: is app_dependencies_path better ?
+    app_bootstrap_config_path: Optional[Path] = None
     inactive_after_s: Optional[float] = None
     log_level: str = "INFO"
     task_queue_poll_interval_s: float = 1.0
@@ -21,7 +30,6 @@ class WorkerConfig(RegistrableConfig, ABC):
 
     class Config:
         env_prefix = "ICIJ_WORKER_"
-        case_sensitive = False
 
     @classmethod
     def parse_file(

--- a/icij-worker/icij_worker/worker/config.py
+++ b/icij-worker/icij_worker/worker/config.py
@@ -7,15 +7,7 @@ from typing import ClassVar, Optional, Union
 from pydantic import Field, Protocol
 from pydantic.parse import load_file
 
-from icij_common.pydantic_utils import ICIJSettings
 from icij_worker.utils.registrable import RegistrableConfig
-
-
-class AsyncAppConfig(ICIJSettings):
-    late_ack: bool = False
-
-    class Config:
-        env_prefix = "ICIJ_APP_"
 
 
 class WorkerConfig(RegistrableConfig, ABC):

--- a/icij-worker/icij_worker/worker/process.py
+++ b/icij-worker/icij_worker/worker/process.py
@@ -30,7 +30,7 @@ class HandleSignalsMixin(LogWithNameMixin, ABC):
     async def _signal_handler(self, signal_name: signal.Signals, *, graceful: bool):
         async with self._cancellation_lock:
             self._worker_cancelled = True
-            self.error("received %s", signal_name)
+            self.exception("received %s", signal_name)
             self._graceful_shutdown = graceful
             if self._work_forever_task is not None:
                 self.info("cancelling worker loop...")

--- a/icij-worker/pyproject.toml
+++ b/icij-worker/pyproject.toml
@@ -19,7 +19,7 @@ target-version = ["py39"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 log_cli = true
-log_cli_level = "DEBUG"
+log_cli_level = "INFO"
 log_cli_format = "[%(levelname)s][%(asctime)s.%(msecs)03d][%(name)s]: %(message)s"
 log_cli_date_format = "%H:%M:%S"
 


### PR DESCRIPTION
# PR description

Implement an early acknowledgment behavior for task message.
The early/late ack behavior is now configurable and early ack is the default to be aligned with Java.


# Changes

## `icij-worker`

### Added
- created the `AsyncAppConfig` which configures the `AsyncApp`. In particular it configures the early/late ack stratgy
- like in java created separate `CancelEvent` (to notify the worker that it should stop working) and a `CancelledEvent` (to notify the TaskManager, that the worker stopped working)
- added a `Worker.requeue(task: Task, is_error: bool)` method to the worker class in order to requeue a task in case of cancellation/failure, when the task message has previously been early acked

### Changed
- refactored the memory and neo4j codebase to be closer to the AMQP behavior and more event based
- refactored and simplified the `AMQPEventPublisher` connection workflow
- renamed `resolve_event_state` into `resolve_update_state`


### Removed
- removed the `ProgressEvent.state`
