### PR TITLE
chore: robust task cancellation

### DIFF
--- a/icij-worker/icij_worker/task_manager/amqp.py
+++ b/icij-worker/icij_worker/task_manager/amqp.py
@@ -21,7 +21,7 @@ from icij_worker.event_publisher.amqp import RobustConnection
 from icij_worker.exceptions import TaskQueueIsFull
 from icij_worker.namespacing import Routing
 from icij_worker.objects import (
-    CancelTaskEvent,
+    CancelEvent,
     Message,
     TaskError,
     TaskEvent,
@@ -147,7 +147,7 @@ class AMQPTaskManager(TaskManager, AMQPMixin):
 
     async def _cancel(self, *, task_id: str, requeue: bool):
         cancelled_at = datetime.now()
-        cancel_event = CancelTaskEvent(
+        cancel_event = CancelEvent(
             task_id=task_id, requeue=requeue, cancelled_at=cancelled_at
         )
         # TODO: for now cancellation is not namespaced, workers from other namespace

--- a/icij-worker/icij_worker/tests/conftest.py
+++ b/icij-worker/icij_worker/tests/conftest.py
@@ -39,7 +39,7 @@ from icij_common.neo4j.test_utils import (  # pylint: disable=unused-import
 from icij_worker import AsyncApp, Neo4JTaskManager, Task
 from icij_worker.app import AsyncAppConfig
 from icij_worker.event_publisher.amqp import AMQPPublisher
-from icij_worker.objects import CancelTaskEvent, TaskState
+from icij_worker.objects import CancelEvent, TaskState
 from icij_worker.task_manager.amqp import AMQPTaskManager
 from icij_worker.task_storage.fs import FSKeyValueStorage
 from icij_worker.task_storage.neo4j_ import (
@@ -164,7 +164,7 @@ RETURN task"""
 @pytest.fixture(scope="function")
 async def populate_cancel_events(
     populate_tasks: List[Task], neo4j_async_app_driver: neo4j.AsyncDriver, request
-) -> List[CancelTaskEvent]:
+) -> List[CancelEvent]:
     namespace = getattr(request, "param", None)
     query_0 = """MATCH (task:_Task { id: $taskId })
 SET task.namespace = $namespace
@@ -173,7 +173,7 @@ RETURN task, event"""
     recs_0, _, _ = await neo4j_async_app_driver.execute_query(
         query_0, now=datetime.now(), taskId=populate_tasks[0].id, namespace=namespace
     )
-    return [CancelTaskEvent.from_neo4j(recs_0[0])]
+    return [CancelEvent.from_neo4j(recs_0[0])]
 
 
 class Recoverable(ValueError):

--- a/icij-worker/icij_worker/tests/task_manager/test_neo4j.py
+++ b/icij-worker/icij_worker/tests/task_manager/test_neo4j.py
@@ -17,7 +17,7 @@ from icij_worker import (
     TaskState,
 )
 from icij_worker.exceptions import MissingTaskResult, TaskAlreadyQueued, TaskQueueIsFull
-from icij_worker.objects import CancelTaskEvent, StacktraceItem
+from icij_worker.objects import CancelEvent, StacktraceItem
 
 
 @pytest_asyncio.fixture(scope="function")
@@ -494,7 +494,7 @@ async def test_task_manager_cancel(
 RETURN task, event"""
     recs, _, _ = await driver.execute_query(query, taskId=task.id)
     assert len(recs) == 1
-    event = CancelTaskEvent.from_neo4j(recs[0])
+    event = CancelEvent.from_neo4j(recs[0])
     # Then
     assert event.task_id == task.id
     assert event.cancelled_at is not None

--- a/icij-worker/icij_worker/tests/test_objects.py
+++ b/icij-worker/icij_worker/tests/test_objects.py
@@ -6,7 +6,7 @@ from typing import Optional
 import pytest
 
 from icij_worker.objects import (
-    CancelTaskEvent,
+    CancelEvent,
     CancelledEvent,
     ErrorEvent,
     PRECEDENCE,
@@ -193,9 +193,7 @@ def test_precedence_sanity_check():
                 state=TaskState.RUNNING,
                 created_at=_CREATED_AT,
             ),
-            CancelTaskEvent(
-                task_id="task-id", requeue=True, cancelled_at=_ANOTHER_TIME
-            ),
+            CancelEvent(task_id="task-id", requeue=True, cancelled_at=_ANOTHER_TIME),
             TaskUpdate(
                 cancelled_at=_ANOTHER_TIME, state=TaskState.QUEUED, progress=0.0
             ),
@@ -207,9 +205,7 @@ def test_precedence_sanity_check():
                 state=TaskState.RUNNING,
                 created_at=_CREATED_AT,
             ),
-            CancelTaskEvent(
-                task_id="task-id", requeue=False, cancelled_at=_ANOTHER_TIME
-            ),
+            CancelEvent(task_id="task-id", requeue=False, cancelled_at=_ANOTHER_TIME),
             TaskUpdate(cancelled_at=_ANOTHER_TIME, state=TaskState.CANCELLED),
         ),
         (

--- a/icij-worker/icij_worker/tests/worker/test_neo4j.py
+++ b/icij-worker/icij_worker/tests/worker/test_neo4j.py
@@ -19,7 +19,7 @@ from icij_worker import (
     TaskState,
 )
 from icij_worker.objects import (
-    CancelTaskEvent,
+    CancelEvent,
     CancelledEvent,
     ErrorEvent,
     ProgressEvent,
@@ -133,7 +133,7 @@ async def test_should_consume_with_namespace(
 
 @pytest.mark.parametrize("worker", [None], indirect=["worker"])
 async def test_worker_consume_cancel_event(
-    populate_cancel_events: List[CancelTaskEvent], worker: Neo4jWorker
+    populate_cancel_events: List[CancelEvent], worker: Neo4jWorker
 ):
     # pylint: disable=unused-argument,protected-access
     # When

--- a/icij-worker/icij_worker/utils/tests.py
+++ b/icij-worker/icij_worker/utils/tests.py
@@ -49,7 +49,7 @@ from icij_worker import (
 from icij_worker.app import AsyncAppConfig
 from icij_worker.event_publisher import EventPublisher
 from icij_worker.exceptions import TaskQueueIsFull, UnknownTask
-from icij_worker.objects import CancelTaskEvent, TaskUpdate, WorkerEvent
+from icij_worker.objects import CancelEvent, TaskUpdate, WorkerEvent
 from icij_worker.task_manager import TaskManager
 from icij_worker.typing_ import PercentProgress
 from icij_worker.utils.dependencies import DependencyInjectionError
@@ -315,7 +315,7 @@ if _has_pytest:
         async def _cancel(self, *, task_id: str, requeue: bool):
             db = self._get_task_db_name(task_id)
             key = self._task_key(task_id=task_id, db=db)
-            event = CancelTaskEvent(
+            event = CancelEvent(
                 task_id=task_id, requeue=requeue, cancelled_at=datetime.now()
             )
             db = self._read()

--- a/icij-worker/icij_worker/worker/neo4j_.py
+++ b/icij-worker/icij_worker/worker/neo4j_.py
@@ -42,7 +42,7 @@ from icij_worker import (
 )
 from icij_worker.event_publisher.neo4j_ import Neo4jEventPublisher
 from icij_worker.exceptions import TaskAlreadyReserved, UnknownTask
-from icij_worker.objects import CancelTaskEvent, WorkerEvent
+from icij_worker.objects import CancelEvent, WorkerEvent
 
 _TASK_MANDATORY_FIELDS_BY_ALIAS = {
     f for f in Task.schema(by_alias=True)["required"] if f != "id"
@@ -249,7 +249,7 @@ LIMIT 1
         event = await res.single(strict=True)
     except ResultNotSingleError:
         return None
-    return CancelTaskEvent.from_neo4j(event)
+    return CancelEvent.from_neo4j(event)
 
 
 async def _acknowledge_task_tx(

--- a/icij-worker/icij_worker/worker/process.py
+++ b/icij-worker/icij_worker/worker/process.py
@@ -28,7 +28,7 @@ class HandleSignalsMixin(LogWithNameMixin, ABC):
             self._setup_child_process_signal_handlers()
 
     async def _signal_handler(self, signal_name: signal.Signals, *, graceful: bool):
-        async with self._cancellation_lock:
+        async with self.cancel_condition:
             self._worker_cancelled = True
             self.exception("received %s", signal_name)
             self._graceful_shutdown = graceful


### PR DESCRIPTION
#  Description

Previously synchronization primitives used to between the worker event loop and the worker task loop didn't ensure that not `CancelledEvent` could be sent after a `TaskResult` and vice-verse.

# Changes

## `icij-worker`

### Fixed
- ensures that  `CancelledEvent` can't be sent after a `TaskResult` for the same task and vice-verse.
