### PR TITLE
chore: improve namespace handling

### DIFF
--- a/icij-worker/icij_worker/namespacing.py
+++ b/icij-worker/icij_worker/namespacing.py
@@ -27,11 +27,11 @@ class Namespacing:
     """Override this class to implement your own mapping between task namespace and
     DBs/amqp queues and so on..."""
 
-    def app_tasks_filter(self, *, task_key: str, app_namespace: str) -> bool:
+    def app_tasks_filter(self, *, task_namespace: str, app_namespace: str) -> bool:
         """Used to filter app task so that the app can be started with a restricted
         namespace. Useful when tasks from the same app must be run by different workers
         """
-        return task_key.startswith(app_namespace)
+        return task_namespace.startswith(app_namespace)
 
     @staticmethod
     @lru_cache

--- a/icij-worker/icij_worker/tests/task_manager/test_amqp.py
+++ b/icij-worker/icij_worker/tests/task_manager/test_amqp.py
@@ -28,7 +28,7 @@ async def test_task_manager_enqueue(
     await task_manager.save_task(task, namespace=None)
 
     # When
-    queued = await task_manager.enqueue(task, namespace=None)
+    queued = await task_manager.enqueue(task)
 
     # Then
     assert queued.state is TaskState.QUEUED
@@ -68,7 +68,7 @@ async def test_task_manager_enqueue_with_namespace(
     await task_manager.save_task(task, namespace=namespace)
 
     # When
-    queued = await task_manager.enqueue(task, namespace=namespace)
+    queued = await task_manager.enqueue(task)
 
     # Then
     assert queued.state is TaskState.QUEUED
@@ -105,11 +105,11 @@ async def test_task_manager_enqueue_should_raise_for_existing_task(
     task = hello_world_task
     task_manager = test_amqp_task_manager
     await task_manager.save_task(task, namespace=None)
-    await task_manager.enqueue(task, namespace=None)
+    await task_manager.enqueue(task)
 
     # When/Then
     with pytest.raises(TaskAlreadyQueued):
-        await task_manager.enqueue(task, namespace=None)
+        await task_manager.enqueue(task)
 
 
 async def test_task_manager_enqueue_should_raise_when_queue_full(
@@ -123,10 +123,10 @@ async def test_task_manager_enqueue_should_raise_when_queue_full(
     await task_manager.save_task(task, namespace=None)
     await task_manager.save_task(other_task, namespace=None)
     async with task_manager:
-        await task_manager.enqueue(task, namespace=None)
+        await task_manager.enqueue(task)
         # When/Then
         with pytest.raises(TaskQueueIsFull):
-            await task_manager.enqueue(other_task, namespace=None)
+            await task_manager.enqueue(other_task)
 
 
 async def test_task_manager_requeue(

--- a/icij-worker/icij_worker/tests/task_manager/test_manager.py
+++ b/icij-worker/icij_worker/tests/task_manager/test_manager.py
@@ -129,7 +129,7 @@ async def test_consume_cancelled_event(
     worker = mock_worker
     task = hello_world_task
     await task_manager.save_task(task, None)
-    await task_manager.enqueue(task, None)
+    await task_manager.enqueue(task)
     await mock_worker.consume()
     worker.current = task
     await task_manager.save_task(task, namespace=None)

--- a/icij-worker/icij_worker/tests/task_manager/test_neo4j.py
+++ b/icij-worker/icij_worker/tests/task_manager/test_neo4j.py
@@ -463,7 +463,7 @@ async def test_task_manager_enqueue(
     await neo4j_task_manager.save_task(task, namespace=None)
 
     # When
-    queued = await neo4j_task_manager.enqueue(task, namespace=None)
+    queued = await neo4j_task_manager.enqueue(task)
 
     # Then
     update = {"state": TaskState.QUEUED}
@@ -481,7 +481,7 @@ async def test_task_manager_enqueue_with_namespace(
     await neo4j_task_manager.save_task(task, namespace=namespace)
 
     # When
-    await neo4j_task_manager.enqueue(task, namespace=namespace)
+    await neo4j_task_manager.enqueue(task)
     query = "MATCH (task:_Task) RETURN task"
     recs, _, _ = await driver.execute_query(query)
     assert len(recs) == 1
@@ -495,11 +495,11 @@ async def test_task_manager_enqueue_should_raise_for_existing_task(
     # Given
     task = hello_world_task
     await neo4j_task_manager.save_task(task, namespace=None)
-    await neo4j_task_manager.enqueue(task, namespace=None)
+    await neo4j_task_manager.enqueue(task)
 
     # When/Then
     with pytest.raises(TaskAlreadyQueued):
-        await neo4j_task_manager.enqueue(task, namespace=None)
+        await neo4j_task_manager.enqueue(task)
 
 
 @pytest.mark.parametrize(
@@ -600,7 +600,7 @@ async def test_task_manager_cancel(
     await neo4j_task_manager.save_task(task, namespace=None)
 
     # When
-    task = await neo4j_task_manager.enqueue(task, namespace=None)
+    task = await neo4j_task_manager.enqueue(task)
     await neo4j_task_manager.cancel(task_id=task.id, requeue=requeue)
     query = """MATCH (task:_Task { id: $taskId })-[
     :_CANCELLED_BY]->(event:_CancelEvent)
@@ -623,9 +623,9 @@ async def test_task_manager_enqueue_should_raise_when_queue_full(
     await task_manager.save_task(_TASK, namespace=None)
 
     # When
-    await task_manager.enqueue(task, namespace=None)
+    await task_manager.enqueue(task)
     with pytest.raises(TaskQueueIsFull):
-        await task_manager.enqueue(_TASK, namespace=None)
+        await task_manager.enqueue(_TASK)
 
 
 async def test_task_manager_save_error(

--- a/icij-worker/icij_worker/tests/test_app.py
+++ b/icij-worker/icij_worker/tests/test_app.py
@@ -8,8 +8,8 @@ from icij_worker import AsyncApp, Namespacing
 
 class DummyNamespacing(Namespacing):
 
-    def app_tasks_filter(self, *, task_key: str, app_namespace: str) -> bool:
-        return task_key.endswith(app_namespace)
+    def app_tasks_filter(self, *, task_namespace: str, app_namespace: str) -> bool:
+        return task_namespace.endswith(app_namespace)
 
 
 @pytest.fixture()
@@ -20,7 +20,7 @@ def namespaced_app() -> AsyncApp:
     def i_m_a():
         return "I'm a"
 
-    @app.task(key="i_m_b")
+    @app.task(name="i_m_b")
     def im_b_task():
         return "I'm b"
 

--- a/icij-worker/icij_worker/tests/worker/test_amqp.py
+++ b/icij-worker/icij_worker/tests/worker/test_amqp.py
@@ -287,7 +287,7 @@ async def test_worker_consume_cancel_events(
         return saved.state is state
 
     async with amqp_worker:
-        await task_manager.enqueue(task, None)
+        await task_manager.enqueue(task)
         t = asyncio.create_task(amqp_worker.work_once())
         amqp_worker._work_once_task = t
         failure = f"failed to consume task event in less than {after_s}s"

--- a/icij-worker/icij_worker/tests/worker/test_worker.py
+++ b/icij-worker/icij_worker/tests/worker/test_worker.py
@@ -55,7 +55,7 @@ async def test_work_once_asyncio_task(mock_worker: MockWorker):
 
     # When
     async with task_manager:
-        await task_manager.enqueue(task, namespace=None)
+        await task_manager.enqueue(task)
         await worker.work_once()
 
         # Then
@@ -132,7 +132,7 @@ async def test_work_once_run_sync_task(mock_worker: MockWorker):
 
     # When
     async with task_manager:
-        await task_manager.enqueue(task, namespace=None)
+        await task_manager.enqueue(task)
         await worker.work_once()
 
         # Then
@@ -207,7 +207,7 @@ async def test_task_wrapper_should_recover_from_recoverable_error(
     await task_manager.save_task(task, namespace=None)
 
     # When/Then
-    task = await task_manager.enqueue(task, namespace=None)
+    task = await task_manager.enqueue(task)
     async with task_manager:
         # Then
         async def _has_retried() -> bool:
@@ -321,7 +321,7 @@ async def test_task_wrapper_should_handle_fatal_error(mock_failing_worker: MockW
     await task_manager.save_task(task, namespace=None)
 
     # When
-    await task_manager.enqueue(task, namespace=None)
+    await task_manager.enqueue(task)
     async with task_manager:
         await worker.work_once()
 
@@ -396,7 +396,7 @@ async def test_task_wrapper_should_handle_unregistered_task(mock_worker: MockWor
     await task_manager.save_task(task, namespace=None)
 
     # When
-    await task_manager.enqueue(task, namespace=None)
+    await task_manager.enqueue(task)
     async with task_manager:
         await worker.work_once()
 
@@ -478,7 +478,7 @@ async def test_work_once_should_not_run_already_cancelled_task(mock_worker: Mock
         w._current = updated  # pylint: disable=protected-access
         return updated
 
-    await task_manager.enqueue(task, namespace=None)
+    await task_manager.enqueue(task)
     # We mock the fact the task is still received but cancelled right after
     with pytest.raises(TaskAlreadyCancelled):
         with patch.object(
@@ -509,7 +509,7 @@ async def test_cancel_running_task(mock_worker: MockWorker, requeue: bool):
         t = asyncio.create_task(worker.work_once())
         worker._work_once_task = t
 
-        await task_manager.enqueue(task, namespace=None)
+        await task_manager.enqueue(task)
         after_s = 2.0
 
         async def _has_state(state: TaskState) -> bool:
@@ -554,7 +554,7 @@ async def test_worker_should_terminate_task_and_cancellation_event_loops(
     await task_manager.save_task(task, namespace=None)
 
     # When
-    await task_manager.enqueue(task, namespace=None)
+    await task_manager.enqueue(task)
     asyncio_tasks = set()
     async with worker, task_manager:
         work_forever_task = asyncio.create_task(worker.work_forever_async())
@@ -635,7 +635,7 @@ async def test_worker_should_keep_working_on_fatal_error_in_task_codebase(
     await task_manager.save_task(task, namespace=None)
 
     # When/Then
-    await task_manager.enqueue(task, namespace=None)
+    await task_manager.enqueue(task)
     with fail_if_exception("fatal_error_task"):
         await worker.work_once()
 
@@ -656,7 +656,7 @@ async def test_worker_should_stop_working_on_fatal_error_in_worker_codebase(
     await task_manager.save_task(task, namespace=None)
 
     # When/Then
-    await task_manager.enqueue(task, namespace=None)
+    await task_manager.enqueue(task)
     with patch.object(worker, "_consume") as mocked_consume:
 
         class _FatalError(Exception): ...


### PR DESCRIPTION
# PR description

Simplify namespacing and task filtering for worker


# Changes

## `passport_service`

### Changed
- removed `Task.task_key` and replaced it with `Task.task_name` + `Task.task_namespace`

