### PR TITLE
chore: simplify namespacing

### DIFF
--- a/icij-worker/icij_worker/tests/worker/test_amqp.py
+++ b/icij-worker/icij_worker/tests/worker/test_amqp.py
@@ -279,7 +279,7 @@ async def test_worker_consume_cancel_events(
         arguments={"duration": duration},
         retries_left=retries_left,
     )
-    await task_manager.save_task(task, None)
+    await task_manager.save_task(task)
     after_s = 2
 
     async def _assert_has_state(state: TaskState) -> bool:

--- a/icij-worker/icij_worker/tests/worker/test_neo4j.py
+++ b/icij-worker/icij_worker/tests/worker/test_neo4j.py
@@ -172,7 +172,9 @@ async def test_worker_negatively_acknowledge(
     assert n_locks == 0
 
 
-_TASK = Task.create(task_id="some-id", task_name="some-task-name", arguments=dict())
+_TASK = Task.create(
+    task_id="some-id", task_name="sleep_for", arguments={"duration": 100}
+)
 _EVENTS = (
     ProgressEvent.from_task(
         safe_copy(_TASK, update={"progress": 0.66, "state": TaskState.RUNNING})
@@ -200,7 +202,7 @@ async def test_worker_publish_event(
 ):
     # When
     driver = worker.driver
-    await neo4j_task_manager.save_task(_TASK, None)
+    await neo4j_task_manager.save_task(_TASK)
     await worker.publish_event(event)
 
     # Then


### PR DESCRIPTION
# PR description

Follwing #29 simplify namespacing further by never explicitely


# Changes

## `passport_service`

### Changed
- removed the `namespace` argument from all high level APIs, the namespace it provided one when registering the task and then never needed anymore

