### PR TITLE
chore: use policies to set queue arguments

### DIFF
--- a/icij-worker/README.md
+++ b/icij-worker/README.md
@@ -1,6 +1,4 @@
-[![Test for icij-worker](https://github.com/ICIJ/icij-python/actions/workflows/tests-worker.yml/badge.svg)](https://github.com/ICIJ/icij-python/actions/workflows/tests-worker.yml)
-
-# ICIJ's async worker library
+# ICIJ's async worker library [![Test for icij-worker](https://github.com/ICIJ/icij-python/actions/workflows/tests-worker.yml/badge.svg)](https://github.com/ICIJ/icij-python/actions/workflows/tests-worker.yml)
 
 ## Installation
 
@@ -47,10 +45,15 @@ Optionally add progress handlers for a better task monitoring:
 
 ```python
 @my_app.task
-def long_running_task(greeted: str, progress: Callable[[float], None]) -> str:
-    progress(0.0)
+async def long_running_task(
+    greeted: str,
+    progress: Optional[Callable[[float], Awaitable]] = None
+) -> str:
+    if progress is not None:
+        await progress(0.0)
     greeting = f"Hello {greeted} !"
-    progress(100.0)
+    if progress is not None:
+        await progress(100.0)
     return greeting
 ```
 
@@ -71,8 +74,6 @@ icij-worker workers start -c worker_config.json -n 2 --backend multiprocessing "
 **depending on the worker configuration additional setup might be required**.
 
 ## Async worker implementations
-
-
 
 - [Neo4j](https://neo4j.com/docs/api/python-driver/current/)
 - [AMQP](https://www.amqp.org/) (`v0.9.1` based on [RabbitMQ](https://www.rabbitmq.com/))

--- a/icij-worker/icij_worker/__init__.py
+++ b/icij-worker/icij_worker/__init__.py
@@ -23,7 +23,7 @@ try:
     from icij_worker.worker.neo4j_ import Neo4jWorker, Neo4jWorkerConfig
     from icij_worker.event_publisher.neo4j_ import Neo4jEventPublisher
     from icij_worker.task_manager.neo4j_ import Neo4JTaskManager, Neo4JTaskManagerConfig
-except ImportError as e:
+except ImportError:
     pass
 
 try:

--- a/icij-worker/icij_worker/backend/mp.py
+++ b/icij-worker/icij_worker/backend/mp.py
@@ -41,8 +41,7 @@ def _mp_work_forever(
             app_deps_extras = dict()
         # For multiprocessing, lifespan dependencies need to be run once per process
         app = AsyncApp.load(app)
-        if worker_group is not None:
-            app.filter_tasks(worker_group)
+        app.filter_tasks(worker_group)
         worker = Worker.from_config(
             config,
             app=app,

--- a/icij-worker/icij_worker/constants.py
+++ b/icij-worker/icij_worker/constants.py
@@ -21,6 +21,8 @@ AMQP_WORKER_EVENTS_X = "exchangeWorkerEvents"
 AMQP_WORKER_EVENTS_QUEUE = "WORKER_EVENT"
 AMQP_WORKER_EVENTS_ROUTING_KEY = "routingKeyWorkerEvents"
 
+AMQP_TASK_QUEUE_PRIORITY = 1000
+
 _CREATED_AT = "created_at"
 _TASK_ID = "task_id"
 

--- a/icij-worker/icij_worker/tests/event_publisher/test_ampq.py
+++ b/icij-worker/icij_worker/tests/event_publisher/test_ampq.py
@@ -31,7 +31,6 @@ _RESULT_ROUTING = Routing(
 )
 
 
-@pytest.mark.asyncio
 async def test_publish_event(rabbit_mq: str, hello_world_task: Task):
     # Given
     task = hello_world_task

--- a/icij-worker/icij_worker/tests/task_manager/test_amqp.py
+++ b/icij-worker/icij_worker/tests/task_manager/test_amqp.py
@@ -18,6 +18,7 @@ from icij_worker.tests.conftest import (
     TestableAMQPTaskManager,
     TestableFSKeyValueStorage,
 )
+from icij_worker.utils.amqp import AMQPManagementClient
 
 
 async def test_task_manager_enqueue(
@@ -118,6 +119,7 @@ async def test_task_manager_enqueue_should_raise_for_existing_task(
 
 async def test_task_manager_enqueue_should_raise_when_queue_full(
     fs_storage: TestableFSKeyValueStorage,
+    management_client: AMQPManagementClient,
     rabbit_mq: str,
     hello_world_task: Task,
     test_async_app: AsyncApp,
@@ -127,7 +129,9 @@ async def test_task_manager_enqueue_should_raise_when_queue_full(
     app._registry = deepcopy(  # pylint: disable=protected-access
         test_async_app.registry
     )
-    task_manager = TestableAMQPTaskManager(app, fs_storage, broker_url=rabbit_mq)
+    task_manager = TestableAMQPTaskManager(
+        app, fs_storage, management_client, broker_url=rabbit_mq
+    )
     task = hello_world_task
     other_task = safe_copy(task, update={"id": "some-other-id"})
     yet_another_task = safe_copy(task, update={"id": "yet-another-id"})

--- a/icij-worker/icij_worker/tests/task_storage/test_postgres.py
+++ b/icij-worker/icij_worker/tests/task_storage/test_postgres.py
@@ -536,7 +536,7 @@ async def test_get_task_group(
     assert ns_1 is None
 
 
-def test_task_manager_with_postgres_storage_from_config(reset_env):
+async def test_task_manager_with_postgres_storage_from_config(reset_env):
     # pylint: disable=unused-argument
     # Given
     class _MySettings(SettingsWithTM, Generic[TM]):

--- a/icij-worker/icij_worker/tests/utils/test_amqp.py
+++ b/icij-worker/icij_worker/tests/utils/test_amqp.py
@@ -1,0 +1,48 @@
+import asyncio
+
+from aio_pika.abc import AbstractRobustQueue
+
+from icij_worker.task_storage.postgres.postgres import logger
+from icij_worker.utils.amqp import AMQPManagementClient, AMQPPolicy, ApplyTo
+
+
+async def test_amqp_management_client_set_policy(
+    management_client: AMQPManagementClient,
+    rabbit_mq,  # pylint: disable=unused-argument
+):
+    # Given
+    client = management_client
+    policy = AMQPPolicy(
+        name="test-policy",
+        priority=1,
+        definition={"max-length": 6},
+        pattern="test-pattern-*",
+        apply_to=ApplyTo.QUEUES,
+    )
+
+    # When
+    async with client:
+        existing_policies = await client.list_policies()
+        assert not existing_policies
+        await client.set_policy(policy=policy)
+        # Then
+        existing_policies = await client.list_policies()
+        assert len(existing_policies) == 1
+        policy = existing_policies[0]
+        expected_policy = {
+            "apply-to": "queues",
+            "definition": {"max-length": 6},
+            "name": "test-policy",
+            "pattern": "test-pattern-*",
+            "priority": 1,
+            "vhost": "/",
+        }
+        assert policy == expected_policy
+
+
+async def _drain_queue(queue: AbstractRobustQueue):
+    async with queue.iterator() as queue_iter:
+        async for message in queue_iter:
+            logger.info("received message: %s", message.body.decode())
+            while True:
+                await asyncio.sleep(0.1)

--- a/icij-worker/poetry.lock
+++ b/icij-worker/poetry.lock
@@ -19,7 +19,7 @@ yarl = "*"
 name = "aiohappyeyeballs"
 version = "2.3.4"
 description = "Happy Eyeballs for asyncio"
-optional = false
+optional = true
 python-versions = "<4.0,>=3.8"
 files = [
     {file = "aiohappyeyeballs-2.3.4-py3-none-any.whl", hash = "sha256:40a16ceffcf1fc9e142fd488123b2e218abc4188cf12ac20c67200e1579baa42"},
@@ -30,7 +30,7 @@ files = [
 name = "aiohttp"
 version = "3.10.1"
 description = "Async http client/server framework (asyncio)"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "aiohttp-3.10.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:47b4c2412960e64d97258f40616efddaebcb34ff664c8a972119ed38fac2a62c"},
@@ -142,7 +142,7 @@ yarl = "*"
 name = "aiosignal"
 version = "1.3.1"
 description = "aiosignal: a list of registered asynchronous callbacks"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "aiosignal-1.3.1-py3-none-any.whl", hash = "sha256:f8376fb07dd1e86a584e4fcdec80b36b7f81aac666ebc724e2c090300dd83b17"},
@@ -170,7 +170,7 @@ typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.11\""}
 name = "async-timeout"
 version = "4.0.3"
 description = "Timeout context manager for asyncio programs"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "async-timeout-4.0.3.tar.gz", hash = "sha256:4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f"},
@@ -181,7 +181,7 @@ files = [
 name = "attrs"
 version = "24.2.0"
 description = "Classes Without Boilerplate"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "attrs-24.2.0-py3-none-any.whl", hash = "sha256:81921eb96de3191c8258c199618104dd27ac608d9366f5e35d011eae1867ede2"},
@@ -254,7 +254,7 @@ test = ["pytest (>=6)"]
 name = "frozenlist"
 version = "1.4.1"
 description = "A list-like structure which implements collections.abc.MutableSequence"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "frozenlist-1.4.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f9aa1878d1083b276b0196f2dfbe00c9b7e752475ed3b682025ff20c1c1f51ac"},
@@ -361,7 +361,7 @@ url = "../icij-common"
 name = "idna"
 version = "3.7"
 description = "Internationalized Domain Names in Applications (IDNA)"
-optional = false
+optional = true
 python-versions = ">=3.5"
 files = [
     {file = "idna-3.7-py3-none-any.whl", hash = "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"},
@@ -443,7 +443,7 @@ files = [
 name = "multidict"
 version = "6.0.5"
 description = "multidict implementation"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "multidict-6.0.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:228b644ae063c10e7f324ab1ab6b548bdf6f8b47f3ec234fef1093bc2735e5f9"},
@@ -1075,7 +1075,7 @@ files = [
 name = "yarl"
 version = "1.9.4"
 description = "Yet another URL library"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "yarl-1.9.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a8c1df72eb746f4136fe9a2e72b0c9dc1da1cbd23b5372f94b5820ff8ae30e0e"},
@@ -1175,10 +1175,10 @@ idna = ">=2.0"
 multidict = ">=4.0"
 
 [extras]
-amqp = ["aio-pika", "psycopg", "sqlitedict", "ujson"]
+amqp = ["aio-pika", "aiohttp", "psycopg", "sqlitedict", "ujson"]
 neo4j = ["neo4j"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "49a17df8f84ba462c8a62278453cf8f8ca1181781be798956f9ac715505829bd"
+content-hash = "4877788bb2a83b13de512f85f3fc9be65b16fa4c0c3aff53469c380e12f712ab"

--- a/icij-worker/pyproject.toml
+++ b/icij-worker/pyproject.toml
@@ -34,9 +34,11 @@ icij-worker = "icij_worker.__main__:cli_app"
 python = "^3.10"
 icij_common = "^0.5.1"
 typer = { extras = ["all"], version = "^0.12.3" }
+typing-extensions = "^4.12.2"
 
 # amqp
 aio-pika = { version = "^9.4.0", optional = true }
+aiohttp =  { version = "^3.9.3", optional = true }
 # fs
 sqlitedict = { version = "^2.1.0", optional = true }
 ujson = { version = "^5.10.0", optional = true }
@@ -46,7 +48,7 @@ neo4j = { version = "^5.0.0", optional = true }
 psycopg = { extras = ["binary", "pool"], version = "^3.2.1", optional = true }
 
 [tool.poetry.extras]
-amqp = ["aio-pika", "psycopg", "sqlitedict", "ujson"]
+amqp = ["aio-pika", "aiohttp", "psycopg", "sqlitedict", "ujson"]
 neo4j = ["neo4j"]
 
 [tool.poetry.group.fs.dependencies]
@@ -60,7 +62,6 @@ pylint = "^3.1.0"
 pytest = "^7.2.1"
 pytest-asyncio = "^0.20.3"
 icij-common = { path = "../icij-common", develop = true, extras = ["neo4j"] }
-aiohttp = "^3.9.3"
 
 
 [build-system]


### PR DESCRIPTION
# Changes
## `icij-worker`
### Changed
- move `max_task_queue_size` from `AsyncApp` and `Worker` to `TaskGroup`
### Fixed
- use policy to pass most of the queue arguments
