### PR TITLE
chore: avoid spawning process when `n_workers=1`

### DIFF
--- a/.github/actions/pylint/action.yml
+++ b/.github/actions/pylint/action.yml
@@ -9,8 +9,9 @@ runs:
     - name: Install dependencies
       shell: bash
       run: |
-        python -m pip install --upgrade pip
-        pip install pylint==3.1.0
+        apt update && apt install pipx
+        pipx ensurepath
+        pipx install pylint==3.1.0
     - name: Run linting test on $ {{ inputs.path }}
       shell: bash
       run: |

--- a/icij-worker/icij_worker/utils/registrable.py
+++ b/icij-worker/icij_worker/utils/registrable.py
@@ -27,6 +27,7 @@ from typing import (
 
 from pydantic import BaseModel, Field
 from pydantic.parse import load_file
+from typing_extensions import Self
 
 from icij_common.pydantic_utils import ICIJSettings
 from icij_worker.utils.imports import VariableNotFound, import_variable
@@ -196,7 +197,7 @@ class FromConfig(ABC):
 
 class RegistrableFromConfig(RegistrableMixin, FromConfig, ABC):
     @classmethod
-    def from_config(cls, config: RegistrableConfig, **extras) -> FromConfig:
+    def from_config(cls, config: RegistrableConfig, **extras) -> Self:
         name = getattr(config, config.registry_key.default).default
         subcls = cls.resolve_class_name(name)
         return subcls._from_config(config, **extras)  # pylint: disable=protected-access


### PR DESCRIPTION
# Changes

## `icij-worker`

### Fixed
- `multiprocessing` fork/spawn is expensive in terms of memory, when the worker pool is launched with a single worker we avoid to do so and use the main process.

