### PR TITLE
chore: use `FSKeyValueStorage` to simplify `MockWorker` and `MockManager` implementations

### DIFF
--- a/icij-worker/icij_worker/task_storage/__init__.py
+++ b/icij-worker/icij_worker/task_storage/__init__.py
@@ -10,7 +10,7 @@ from icij_worker.routing_strategy import RoutingStrategy
 
 class TaskStorageConfig(ABC):
     @abstractmethod
-    def to_storage(self, routing_strategy: Optional[RoutingStrategy]) -> TaskStorage:
+    def to_storage(self) -> TaskStorage:
         pass
 
 

--- a/icij-worker/icij_worker/task_storage/key_value.py
+++ b/icij-worker/icij_worker/task_storage/key_value.py
@@ -1,10 +1,12 @@
 from abc import ABC, abstractmethod
-from typing import Dict, List, Optional, Type
+from typing import Dict, List, Optional, Type, Union
 
-from icij_worker import RoutingStrategy, Task, TaskError, ResultEvent
+from icij_worker import ResultEvent, Task, TaskError
 from icij_worker.exceptions import UnknownTask
 from icij_worker.objects import ErrorEvent, TaskUpdate
 from icij_worker.task_storage import TaskStorage
+
+DBItem = Union[List, Dict]
 
 
 class KeyValueStorage(TaskStorage, ABC):
@@ -12,22 +14,24 @@ class KeyValueStorage(TaskStorage, ABC):
     _tasks_db_name = "tasks"
     _results_db_name = "results"
     _errors_db_name = "errors"
-    _routing_strategy: RoutingStrategy
 
     async def save_task_(self, task: Task, group: Optional[str]) -> bool:
         """When possible override this to be transactional"""
         key = self._key(task.id, obj_cls=ResultEvent)
         new_task = False
         try:
-            ns = await self.get_task_group(task_id=task.id)
+            db_group = await self.get_task_group(task_id=task.id)
         except UnknownTask:
             new_task = True
             task = task.dict(exclude_unset=True)
             task["group"] = group
             await self._insert(self._tasks_db_name, task, key=key)
         else:
-            if ns != group:
-                msg = f"DB task group ({ns}) differs from" f" save task group: {group}"
+            if db_group != group:
+                msg = (
+                    f"DB task group ({db_group}) differs from"
+                    f" save task group: {group}"
+                )
                 raise ValueError(msg)
             update = TaskUpdate.from_task(task).dict(exclude_none=True)
             await self._update(self._tasks_db_name, update, key=key)
@@ -80,13 +84,13 @@ class KeyValueStorage(TaskStorage, ABC):
     async def _read_key(self, db: str, *, key: str) -> Dict: ...
 
     @abstractmethod
-    async def _insert(self, db: str, obj: Dict, *, key: str) -> str: ...
+    async def _insert(self, db: str, obj: DBItem, *, key: str) -> str: ...
 
     @abstractmethod
-    async def _update(self, db: str, update: Dict, *, key: str) -> str: ...
+    async def _update(self, db: str, update: DBItem, *, key: str) -> str: ...
 
     @abstractmethod
-    async def _add_to_array(self, db: str, obj: Dict, *, key: str) -> str: ...
+    async def _add_to_array(self, db: str, obj: DBItem, *, key: str) -> str: ...
 
     @abstractmethod
     def _key(self, task_id: str, obj_cls: Type) -> str: ...

--- a/icij-worker/icij_worker/tests/cli/test_workers.py
+++ b/icij-worker/icij_worker/tests/cli/test_workers.py
@@ -23,7 +23,7 @@ def test_workers_help(cli_runner: CliRunner, help_command: str):
 @pytest.fixture()
 def mock_worker_in_env(tmp_path):  # pylint: disable=unused-argument
     os.environ["ICIJ_WORKER_TYPE"] = "mock"
-    db_path = tmp_path / "mock-db.json"
+    db_path = tmp_path
     os.environ["ICIJ_WORKER_DB_PATH"] = str(db_path)
 
 

--- a/icij-worker/icij_worker/tests/conftest.py
+++ b/icij-worker/icij_worker/tests/conftest.py
@@ -66,8 +66,6 @@ from icij_worker.utils.tests import (  # pylint: disable=unused-import
     MockWorker,
     app_config,
     late_ack_app_config,
-    mock_db,
-    mock_db_session,
     test_async_app,
     test_async_app_late,
 )
@@ -576,7 +574,7 @@ async def count_locks(driver: neo4j.AsyncDriver, db: str) -> int:
     scope="function",
     params=[{"app": "test_async_app"}, {"app": "test_async_app_late"}],
 )
-def mock_worker(mock_db: Path, request) -> MockWorker:
+def mock_worker(fs_storage_path: Path, request) -> MockWorker:
     param = getattr(request, "param", dict()) or dict()
     app = request.getfixturevalue(param.get("app", "test_async_app"))
     group = param.get("group")
@@ -584,7 +582,7 @@ def mock_worker(mock_db: Path, request) -> MockWorker:
         app,
         "test-worker",
         group=group,
-        db_path=mock_db,
+        db_path=fs_storage_path,
         poll_interval_s=0.1,
         teardown_dependencies=False,
     )

--- a/icij-worker/icij_worker/tests/task_manager/test_manager.py
+++ b/icij-worker/icij_worker/tests/task_manager/test_manager.py
@@ -14,10 +14,10 @@ from icij_worker.utils.tests import MockManager, MockWorker
 
 
 @pytest.fixture
-def mock_manager(mock_db, request) -> MockManager:
+def mock_manager(fs_storage_path, request) -> MockManager:
     app = getattr(request, "param", "test_async_app")
     app = request.getfixturevalue(app)
-    task_manager = MockManager(app, mock_db)
+    task_manager = MockManager(app, fs_storage_path)
     return task_manager
 
 

--- a/icij-worker/icij_worker/tests/worker/conftest.py
+++ b/icij-worker/icij_worker/tests/worker/conftest.py
@@ -8,11 +8,7 @@ import pytest
 from icij_worker import AsyncApp, RoutingStrategy
 
 # noinspection PyUnresolvedReferences
-from icij_worker.utils.tests import (  # pylint: disable=unused-import
-    MockWorker,
-    mock_db,
-    mock_db_session,
-)
+from icij_worker.utils.tests import MockWorker  # pylint: disable=unused-import
 
 
 def make_app(routing_strategy: Optional[RoutingStrategy] = None):

--- a/icij-worker/icij_worker/tests/worker/test_worker.py
+++ b/icij-worker/icij_worker/tests/worker/test_worker.py
@@ -25,13 +25,13 @@ from icij_worker.worker.worker import add_missing_args
     scope="function",
     params=["test_failing_async_app_late_ack", "test_failing_async_app"],
 )
-def mock_failing_worker(mock_db: Path, request) -> MockWorker:
+def mock_failing_worker(fs_storage_path: Path, request) -> MockWorker:
     app = request.getfixturevalue(request.param)
     worker = MockWorker(
         app,
         "test-worker",
         group=None,
-        db_path=mock_db,
+        db_path=fs_storage_path,
         poll_interval_s=0.1,
     )
     return worker


### PR DESCRIPTION
# Changes

## `icij-worker`

### Added
- use `FSKeyValueStorage` to simplify `MockWorker` and `MockManager` implementations rather than the relying on the flaky file system to store task in mock implem
