### PR TITLE
feature: implement an HTTP `TaskClient`

### DIFF
--- a/icij-common/icij_common/es/__init__.py
+++ b/icij-common/icij_common/es/__init__.py
@@ -251,6 +251,9 @@ def must_no(*queries: Dict) -> Dict:
     return {MUST: list(queries)}
 
 
+must_not = must_no
+
+
 def with_sort(*, query: Dict, sort: Dict) -> Dict:
     if SORT not in query:
         query[SORT] = []

--- a/icij-worker/icij_worker/task_client.py
+++ b/icij-worker/icij_worker/task_client.py
@@ -1,0 +1,30 @@
+import uuid
+from typing import Any, Dict, Optional
+
+from icij_worker import Task
+from icij_worker.utils.http import AiohttpClient
+
+
+class TaskClient(AiohttpClient):
+    def __init__(self, datashare_url: str):
+        super().__init__(datashare_url)
+
+    async def create_task(
+        self,
+        name: str,
+        args: Dict[str, Any],
+        *,
+        id_: Optional[str] = None,
+        group: Optional[str] = None,
+    ):
+        if id_ is None:
+            id_ = _generate_task_id(name)
+        task = Task.create(task_id=id_, task_name=name, args=args)
+        url = f"/api/task/{id_}"
+        data = {"task": task, "group": group}
+        async with self._put(url, json=data):
+            pass
+
+
+def _generate_task_id(task_name: str) -> str:
+    return f"{task_name}-{uuid.uuid4()}"

--- a/icij-worker/icij_worker/tests/worker/test_amqp.py
+++ b/icij-worker/icij_worker/tests/worker/test_amqp.py
@@ -14,7 +14,6 @@ from aio_pika import (
 )
 from pydantic import Field
 
-from conftest import RABBITMQ_TEST_PASSWORD, RABBITMQ_TEST_USER
 from icij_common.pydantic_utils import safe_copy
 from icij_common.test_utils import async_true_after, fail_if_exception
 from icij_worker import (
@@ -41,7 +40,9 @@ from icij_worker.tests.conftest import (
     DEFAULT_VHOST,
     RABBITMQ_MANAGEMENT_PORT,
     RABBITMQ_TEST_HOST,
+    RABBITMQ_TEST_PASSWORD,
     RABBITMQ_TEST_PORT,
+    RABBITMQ_TEST_USER,
     TestableAMQPPublisher,
     get_queue_size,
 )

--- a/icij-worker/icij_worker/utils/http.py
+++ b/icij-worker/icij_worker/utils/http.py
@@ -1,0 +1,54 @@
+import logging
+from contextlib import asynccontextmanager
+from typing import Any, AsyncContextManager, Optional
+
+from aiohttp import BasicAuth, ClientResponse, ClientResponseError, ClientSession
+from aiohttp.client import _RequestOptions
+from aiohttp.typedefs import StrOrURL
+from typing_extensions import Unpack
+
+logger = logging.getLogger(__name__)
+
+
+class AiohttpClient(AsyncContextManager):
+    def __init__(self, base_url: str, auth: Optional[BasicAuth] = None):
+        self._base_url = base_url
+        self._auth = auth
+        self._session: Optional[ClientSession] = None
+
+    async def __aenter__(self):
+        self._session = ClientSession(self._base_url, auth=self._auth)
+        await self._session.__aenter__()
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        await self._session.__aexit__(exc_type, exc_value, traceback)
+
+    @asynccontextmanager
+    async def _put(self, url: StrOrURL, *, data: Any = None, **kwargs: Any):
+        async with self._session.put(url, data=data, **kwargs) as res:
+            _raise_for_status(res)
+            yield res
+
+    @asynccontextmanager
+    async def _get(self, url: StrOrURL, *, allow_redirects: bool = True, **kwargs: Any):
+        async with self._session.get(
+            url, allow_redirects=allow_redirects, **kwargs
+        ) as res:
+            _raise_for_status(res)
+            yield res
+
+    @asynccontextmanager
+    async def _delete(self, url: StrOrURL, **kwargs: Unpack[_RequestOptions]):
+        async with self._session.delete(url, **kwargs) as res:
+            _raise_for_status(res)
+            yield res
+
+
+def _raise_for_status(res: ClientResponse):
+    try:
+        res.raise_for_status()
+    except ClientResponseError as e:
+        msg = "request to %s, failed with reason %s"
+        logger.exception(msg, res.request_info, res.reason)
+        raise e

--- a/icij-worker/pyproject.toml
+++ b/icij-worker/pyproject.toml
@@ -25,7 +25,7 @@ log_cli = true
 log_cli_level = "INFO"
 log_cli_format = "[%(levelname)s][%(asctime)s.%(msecs)03d][%(name)s]: %(message)s"
 log_cli_date_format = "%H:%M:%S"
-
+markers = [ "pull" ]
 
 [tool.poetry.scripts]
 icij-worker = "icij_worker.__main__:cli_app"


### PR DESCRIPTION
# Description

Implement an HTTP task client which will allow users to create task.
Since we don't support task dependency yet, creating a task as part of another task will probably be a recurrent pattern.

# Changes
## `icij-worker`

### Added
- created an HTTP `TaskClient` with the `create_task` method
