### PR TITLE
fix: use only durable queues and exchanges

### DIFF
--- a/icij-worker/icij_worker/task_manager/amqp.py
+++ b/icij-worker/icij_worker/task_manager/amqp.py
@@ -232,10 +232,7 @@ class AMQPTaskManager(TaskManager, AMQPMixin):
         for routing in self._other_routings:
             logger.debug("(re)declaring routing %s...", routing)
             await self._create_routing(
-                routing,
-                declare_exchanges=True,
-                declare_queues=True,
-                durable_queues=True,
+                routing, declare_exchanges=True, declare_queues=True
             )
         await self._create_routing(
             self.worker_evt_routing(), declare_exchanges=True, declare_queues=False
@@ -276,8 +273,5 @@ class AMQPTaskManager(TaskManager, AMQPMixin):
             )
             await self._management_client.set_policy(group_policy)
             await self._create_routing(
-                routing,
-                declare_exchanges=True,
-                declare_queues=True,
-                durable_queues=True,
+                routing, declare_exchanges=True, declare_queues=True
             )

--- a/icij-worker/icij_worker/utils/amqp.py
+++ b/icij-worker/icij_worker/utils/amqp.py
@@ -253,17 +253,13 @@ class AMQPMixin:
         *,
         declare_exchanges: bool,
         declare_queues: bool = True,
-        durable_queues: bool = True,
     ) -> Tuple[AbstractQueueIterator, AbstractExchange, Optional[AbstractExchange]]:
         await self._exit_stack.enter_async_context(
             cast(AbstractAsyncContextManager, self._channel)
         )
         dlq_ex = None
         await self._create_routing(
-            routing,
-            declare_exchanges=declare_exchanges,
-            declare_queues=declare_queues,
-            durable_queues=durable_queues,
+            routing, declare_exchanges=declare_exchanges, declare_queues=declare_queues
         )
         ex = await self._channel.get_exchange(routing.exchange.name, ensure=False)
         queue = await self._channel.get_queue(routing.queue_name, ensure=False)
@@ -278,7 +274,6 @@ class AMQPMixin:
         *,
         declare_exchanges: bool = True,
         declare_queues: bool = True,
-        durable_queues: bool = True,
     ):
         if declare_exchanges:
             x = await self._channel.declare_exchange(
@@ -294,7 +289,6 @@ class AMQPMixin:
                 routing.dead_letter_routing,
                 declare_exchanges=declare_exchanges,
                 declare_queues=declare_queues,
-                durable_queues=durable_queues,
             )
             if queue_args is None:
                 queue_args = dict()
@@ -310,7 +304,7 @@ class AMQPMixin:
             if self._is_qpid:
                 queue_args = dict()
             queue = await self._channel.declare_queue(
-                routing.queue_name, durable=durable_queues, arguments=queue_args
+                routing.queue_name, durable=True, arguments=queue_args
             )
         else:
             queue = await self._channel.get_queue(routing.queue_name, ensure=True)

--- a/icij-worker/icij_worker/worker/amqp.py
+++ b/icij-worker/icij_worker/worker/amqp.py
@@ -120,7 +120,7 @@ class AMQPWorker(Worker, AMQPMixin):
         event_transient_queue = await self._channel.get_queue(
             self._worker_evt_routing.queue_name
         )
-        await event_transient_queue.delete(if_empty=False, if_unused=False)
+        await event_transient_queue.delete(if_empty=True, if_unused=False)
         await self._exit_stack.__aexit__(exc_type, exc_val, exc_tb)
 
     async def _bind_task_queue(self):
@@ -145,8 +145,7 @@ class AMQPWorker(Worker, AMQPMixin):
     async def _bind_worker_event_queue(self):
         self._worker_evt_queue_iterator, _, _ = await self._get_queue_iterator(
             self._worker_evt_routing,
-            declare_queues=True,  # The worker always creates its own transient queue
-            durable_queues=False,
+            declare_queues=True,
             declare_exchanges=self._declare_exchanges,
         )
         self._worker_evt_queue_iterator = cast(


### PR DESCRIPTION
# Bug description

Transient queues are not supported in a replicated/mirrored setup. 
Use only durable queues


# Changes

## `icij-worker`

### Fixed
- fix: use only durable queues and exchanges
