### PR TITLE
fix: failed AMQP task requeuing forever

### DIFF
--- a/icij-worker/poetry.lock
+++ b/icij-worker/poetry.lock
@@ -1009,23 +1009,6 @@ docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
 testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
 
 [[package]]
-name = "pytest-retry"
-version = "1.6.3"
-description = "Adds the ability to retry flaky tests in CI environments"
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "pytest_retry-1.6.3-py3-none-any.whl", hash = "sha256:e96f7df77ee70b0838d1085f9c3b8b5b7d74bf8947a0baf32e2b8c71b27683c8"},
-    {file = "pytest_retry-1.6.3.tar.gz", hash = "sha256:36ccfa11c8c8f9ddad5e20375182146d040c20c4a791745139c5a99ddf1b557d"},
-]
-
-[package.dependencies]
-pytest = ">=7.0.0"
-
-[package.extras]
-dev = ["black", "flake8", "isort", "mypy"]
-
-[[package]]
 name = "pytz"
 version = "2024.2"
 description = "World timezone definitions, modern and historical"
@@ -1357,4 +1340,4 @@ neo4j = ["neo4j"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "808cd6db5f5c29bca8c1aa0e30d40a5ca46ae4b91c7b261bbb9fe82d68e428ac"
+content-hash = "2930948de4783b3f5952a6f7c7553d9cae9807a52c4725be40e98c8cc9bc4b50"

--- a/icij-worker/pyproject.toml
+++ b/icij-worker/pyproject.toml
@@ -61,7 +61,6 @@ pika = "^1.3"
 pylint = "^3.1.0"
 pytest = "^7.2.1"
 pytest-asyncio = "^0.20.3"
-pytest-retry = "^1.6.3"
 icij-common = { path = "../icij-common", develop = true, extras = ["neo4j"] }
 
 


### PR DESCRIPTION
# Bug description

When error occurred using the AMQP worker, task were requeued forever until the `x-delivery-count` reached 0.

This is because the `AMQPWorker` does a `publish_error_event` then a `.nack` of the current task message.

However nacking the current task message redistributes it to the worker. The expected correct flow is the following:
- `publish_error_event`
- `ack` the current task message
- let the TM handle the `ErrorEvent` and requeue / dlq the task as needed



# Changes

## `icij-worker`

### Fixed
- fix the `AMQPWorker._negatively_acknowledge` by doing an `ack` instead of an `nack`