### PR TITLE
chore: enlarge typer version bounds

### DIFF
--- a/icij-worker/poetry.lock
+++ b/icij-worker/poetry.lock
@@ -1225,13 +1225,13 @@ files = [
 
 [[package]]
 name = "typer"
-version = "0.13.1"
+version = "0.13.0"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "typer-0.13.1-py3-none-any.whl", hash = "sha256:5b59580fd925e89463a29d363e0a43245ec02765bde9fb77d39e5d0f29dd7157"},
-    {file = "typer-0.13.1.tar.gz", hash = "sha256:9d444cb96cc268ce6f8b94e13b4335084cef4c079998a9f4851a90229a3bd25c"},
+    {file = "typer-0.13.0-py3-none-any.whl", hash = "sha256:d85fe0b777b2517cc99c8055ed735452f2659cd45e451507c76f48ce5c1d00e2"},
+    {file = "typer-0.13.0.tar.gz", hash = "sha256:f1c7198347939361eec90139ffa0fd8b3df3a2259d5852a0f7400e476d95985c"},
 ]
 
 [package.dependencies]
@@ -1452,4 +1452,4 @@ neo4j = ["neo4j"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "cca77c868c4ff3aee3d3ddfc19663199636530fdc3d2fbd67c31847775712abc"
+content-hash = "8b5a24fb9f3fa56770e9c957250d5b4539d9e59752ec5398fcb575e2054e4b4e"

--- a/icij-worker/pyproject.toml
+++ b/icij-worker/pyproject.toml
@@ -33,7 +33,7 @@ icij-worker = "icij_worker.__main__:cli_app"
 [tool.poetry.dependencies]
 python = "^3.10"
 icij_common = "^0.6.0"
-typer = { extras = ["all"], version = "^0.13.1" }
+typer = { extras = ["all"], version = ">=0.12.5,<0.14" }
 typing-extensions = "^4.12.2"
 
 # amqp


### PR DESCRIPTION
# Changes

## `icij-worker`

### Fixed
- enlarged `typer` version bounds