### PR TITLE
fix(icij-worker): qpid connection

### DIFF
--- a/icij-worker/icij_worker/cli/tasks.py
+++ b/icij-worker/icij_worker/cli/tasks.py
@@ -11,7 +11,7 @@ import typer
 from icij_worker import TaskState
 from icij_worker.cli.utils import AsyncTyper, eprint
 from icij_worker.http_ import TaskClient
-from icij_worker.objects import READY_STATES, Task, TaskError
+from icij_worker.objects import ErrorEvent, READY_STATES, Task
 
 logger = logging.getLogger(__name__)
 
@@ -155,7 +155,8 @@ async def _handle_alive(
         await _handle_ready(task, client)
 
 
-def _format_error(error: TaskError) -> str:
+def _format_error(error: ErrorEvent) -> str:
+    error = error.error
     stack = StackSummary.from_list(
         [FrameSummary(f.name, f.lineno, f.name) for f in error.stacktrace]
     )

--- a/icij-worker/icij_worker/worker/worker.py
+++ b/icij-worker/icij_worker/worker/worker.py
@@ -182,9 +182,9 @@ class Worker(
         self._started_task_consumption_evt.set()
         task = await self._consume()
         msg = 'Task(id="%s") locked'
-        if task.max_retries is not None:
+        if task.max_retries is not None and task.retries_left is not None:
             msg += (
-                f", tentative ({task.max_retries - task.retries_left}"
+                f", retry ({task.max_retries - task.retries_left}"
                 f"/{task.max_retries})"
             )
         self.info(msg, task.id)


### PR DESCRIPTION
# Changes

## `icij-worker`

### Fixed
- fixed a bug were qpid robust connection was used all the time even when using RabbitMQ